### PR TITLE
Accept YAML lists in configuration and harden empty-config handling

### DIFF
--- a/custom_components/ha_scheduler/config_flow.py
+++ b/custom_components/ha_scheduler/config_flow.py
@@ -75,19 +75,21 @@ def _get_schedule_type_display(schedule_type: str) -> str:
     return display_names.get(schedule_type, schedule_type)
 
 
-def _validate_yaml_config(yaml_str: str) -> dict | None:
+def _validate_yaml_config(yaml_str: str) -> dict | list | None:
     """Validate YAML configuration string.
 
-    Returns parsed dict if valid, raises ValueError if invalid.
+    Returns the parsed structure (dict or list) if valid, ``None`` for an
+    empty string, and raises ``ValueError`` if invalid.
     """
     if not yaml_str or not yaml_str.strip():
         return None
 
     try:
         parsed = yaml.safe_load(yaml_str)
-        if not isinstance(parsed, dict):
+        if not isinstance(parsed, (dict, list)):
             raise ValueError(
-                "Configuration must be a YAML dictionary, not a simple value"
+                "Configuration must be a YAML structure (dict or list), "
+                "not a simple value"
             )
         return parsed
     except yaml.YAMLError as err:
@@ -424,7 +426,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 )
                 if config_yaml:
                     config_dict = _validate_yaml_config(config_yaml)
-                    if config_dict:
+                    if config_dict is not None:
                         data["configuration"] = config_dict
 
                 # Get current schedules and validate for conflicts
@@ -454,7 +456,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         defaults = user_input if user_input and errors else self._schedule_data
         # Convert configuration dict back to YAML string for display
         config_value = defaults.get("configuration", "")
-        if isinstance(config_value, dict):
+        if isinstance(config_value, (dict, list)):
             config_value = yaml.dump(
                 config_value, default_flow_style=False, sort_keys=False
             ).strip()
@@ -563,6 +565,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         and self.hass.config.country
                     ):
                         data["country_code"] = self.hass.config.country
+                    else:
+                        _LOGGER.debug(
+                            "No country configured in Home Assistant; week "
+                            "schedules default to Monday-first weeks"
+                        )
                 except AttributeError:
                     # Fallback - try to get from locale or default to None
                     pass
@@ -573,7 +580,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 )
                 if config_yaml:
                     config_dict = _validate_yaml_config(config_yaml)
-                    if config_dict:
+                    if config_dict is not None:
                         data["configuration"] = config_dict
 
                 errors.update(self._validate_week_schedule(data))
@@ -607,7 +614,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         defaults = user_input if user_input and errors else self._schedule_data
         # Convert configuration dict back to YAML string for display
         config_value = defaults.get("configuration", "")
-        if isinstance(config_value, dict):
+        if isinstance(config_value, (dict, list)):
             config_value = yaml.dump(
                 config_value, default_flow_style=False, sort_keys=False
             ).strip()
@@ -710,7 +717,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 )
                 if config_yaml:
                     config_dict = _validate_yaml_config(config_yaml)
-                    if config_dict:
+                    if config_dict is not None:
                         data["configuration"] = config_dict
 
                 # Get current schedules and validate for conflicts
@@ -739,7 +746,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         defaults = user_input if user_input and errors else self._schedule_data
         # Convert configuration dict back to YAML string for display
         config_value = defaults.get("configuration", "")
-        if isinstance(config_value, dict):
+        if isinstance(config_value, (dict, list)):
             config_value = yaml.dump(
                 config_value, default_flow_style=False, sort_keys=False
             ).strip()
@@ -942,7 +949,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 )
                 if config_yaml:
                     config_dict = _validate_yaml_config(config_yaml)
-                    if config_dict:
+                    if config_dict is not None:
                         data["configuration"] = config_dict
 
                 schedules = self._get_service_schedules()
@@ -974,7 +981,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         defaults = user_input if user_input and errors else self._schedule_data
         config_value = defaults.get("configuration", "")
-        if isinstance(config_value, dict):
+        if isinstance(config_value, (dict, list)):
             config_value = yaml.dump(
                 config_value, default_flow_style=False, sort_keys=False
             ).strip()
@@ -1201,7 +1208,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
                 new_services[self._service_id] = {
                     **new_services[self._service_id],
-                    "configuration": config_dict or {},
+                    "configuration": config_dict if config_dict is not None else {},
                 }
 
                 updated_options = {**entry.options, "services": new_services}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2143,7 +2143,11 @@ async def test_options_flow_add_date_schedule_with_configuration(
 async def test_options_flow_invalid_yaml_non_dict(
     hass: HomeAssistant, create_service_entry
 ) -> None:
-    """Test non-dict YAML is rejected for schedule configuration."""
+    """Test scalar YAML is rejected for schedule configuration.
+
+    Lists and dicts are valid YAML structures and are accepted; only simple
+    scalar values must be rejected.
+    """
     entry = create_service_entry()
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -2166,19 +2170,19 @@ async def test_options_flow_invalid_yaml_non_dict(
             "start_day": 1,
             "end_month": "12",
             "end_day": 31,
-            "configuration": "- one\n- two",
+            "configuration": "just a string",
         },
     )
 
     assert result["type"] == FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_yaml_with_details"
-    assert "YAML dictionary" in result["description_placeholders"]["details"]
+    assert "YAML structure" in result["description_placeholders"]["details"]
 
 
 async def test_default_configuration_invalid_yaml_non_dict(
     hass: HomeAssistant, create_service_entry
 ) -> None:
-    """Test non-dict YAML is rejected for default configuration."""
+    """Test scalar YAML is rejected for default configuration."""
     entry = create_service_entry()
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -2191,12 +2195,123 @@ async def test_default_configuration_invalid_yaml_non_dict(
     )
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        {"configuration": "- one\n- two"},
+        {"configuration": "just a string"},
     )
 
     assert result["type"] == FlowResultType.FORM
     assert result["errors"]["base"] == "invalid_yaml_with_details"
-    assert "YAML dictionary" in result["description_placeholders"]["details"]
+    assert "YAML structure" in result["description_placeholders"]["details"]
+
+
+async def test_options_flow_list_configuration_accepted(
+    hass: HomeAssistant, create_service_entry
+) -> None:
+    """A list-structured YAML configuration is accepted and stored."""
+    entry = create_service_entry()
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"next_step_id": "add_schedule"},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"schedule_type": "date"},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "name": "List Config Schedule",
+            "start_month": "1",
+            "start_day": 1,
+            "end_month": "12",
+            "end_day": 31,
+            "configuration": "- one\n- two",
+        },
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    schedules = get_schedules_from_entry(entry)
+    schedule = list(schedules.values())[0]
+    assert schedule["configuration"] == ["one", "two"]
+
+
+async def test_options_flow_list_configuration_round_trips_in_edit_form(
+    hass: HomeAssistant, create_service_entry
+) -> None:
+    """A stored list configuration is rendered back as YAML in the edit form."""
+    schedules = {
+        "test-id": {
+            "uid": "test-id",
+            "name": "List Schedule",
+            "schedule_type": "date",
+            "start_month": 6,
+            "start_day": 1,
+            "end_month": 8,
+            "end_day": 31,
+            "configuration": ["one", "two"],
+        }
+    }
+    entry = create_service_entry(schedules=schedules)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(
+        entry.entry_id, context={"show_advanced_options": False}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": "edit_schedule"},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"schedule_id": "test-id"},
+    )
+    assert result["step_id"] == "configure_date"
+
+    schema = result["data_schema"].schema
+    config_key = next(key for key in schema if str(key) == "configuration")
+    # The list must be rendered as YAML, not as a Python repr.
+    assert config_key.default() == "- one\n- two"
+
+
+async def test_options_flow_explicit_empty_dict_configuration_stored(
+    hass: HomeAssistant, create_service_entry
+) -> None:
+    """An explicit empty dict configuration is stored, not silently dropped."""
+    entry = create_service_entry()
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"next_step_id": "add_schedule"},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"schedule_type": "date"},
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "name": "Empty Config Schedule",
+            "start_month": "1",
+            "start_day": 1,
+            "end_month": "12",
+            "end_day": 31,
+            "configuration": "{}",
+        },
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    schedules = get_schedules_from_entry(entry)
+    schedule = list(schedules.values())[0]
+    assert "configuration" in schedule
+    assert schedule["configuration"] == {}
 
 
 async def test_options_flow_add_week_schedule_whole_week_no_types(

--- a/tests/test_config_flow_edge_cases.py
+++ b/tests/test_config_flow_edge_cases.py
@@ -5,9 +5,51 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.ha_scheduler.config_flow import _validate_yaml_config
 from custom_components.ha_scheduler.const import DOMAIN
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+def test_validate_yaml_config_accepts_dict() -> None:
+    """A YAML mapping is parsed and returned as a dict."""
+    assert _validate_yaml_config("color: red\nbrightness: 75") == {
+        "color": "red",
+        "brightness": 75,
+    }
+
+
+def test_validate_yaml_config_accepts_list() -> None:
+    """A YAML sequence is a valid structure and returned as a list."""
+    assert _validate_yaml_config("- one\n- two") == ["one", "two"]
+
+
+def test_validate_yaml_config_accepts_empty_dict() -> None:
+    """An explicit empty mapping is preserved (not collapsed to None)."""
+    assert _validate_yaml_config("{}") == {}
+
+
+def test_validate_yaml_config_accepts_empty_list() -> None:
+    """An explicit empty sequence is preserved (not collapsed to None)."""
+    assert _validate_yaml_config("[]") == []
+
+
+def test_validate_yaml_config_blank_returns_none() -> None:
+    """Blank/whitespace input returns None rather than raising."""
+    assert _validate_yaml_config("") is None
+    assert _validate_yaml_config("   \n  ") is None
+
+
+def test_validate_yaml_config_rejects_scalar() -> None:
+    """A bare scalar value is rejected with a structure error."""
+    with pytest.raises(ValueError, match="YAML structure"):
+        _validate_yaml_config("just a string")
+
+
+def test_validate_yaml_config_rejects_invalid_yaml() -> None:
+    """Malformed YAML is reported as invalid."""
+    with pytest.raises(ValueError, match="Invalid YAML:"):
+        _validate_yaml_config("invalid: yaml: [")
 
 
 async def test_config_flow_duplicate_name(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

Remediates functional issues found in a review of the config flow's YAML configuration handling. SPEC.md says configuration must accept a YAML structure (dict **or** list), but the validator only accepted dicts and silently dropped explicit empty structures.

## Changes
- **`_validate_yaml_config` accepts dict or list** (spec compliance). Only scalar values are rejected, now with a clearer message: *"Configuration must be a YAML structure (dict or list), not a simple value"*.
- **Explicit empty `{}`/`[]` configs are stored, not dropped** — the four schedule handlers changed from `if config_dict:` truthiness to `is not None`; `default_configuration` likewise preserves explicit empty/list configs.
- **Edit forms round-trip list configs** — `isinstance(config_value, (dict, list))` so a stored list re-renders as YAML instead of a Python repr.
- **country_code diagnosability** — `async_step_configure_week` logs a debug message when no HA country is configured, so the Monday-first week fallback is observable (no behavior change).

## Tests
- New config-flow tests: list-structured YAML accepted & stored, list config round-trips in the edit form, explicit `{}` stored, scalar YAML still rejected.
- New unit tests for `_validate_yaml_config` (dict / list / empty dict / empty list / blank / scalar / malformed).
- Repurposed two existing "non-dict rejected" tests to assert **scalar** rejection (lists are now valid).

## Verification
- `pytest tests/` → **255 passed** (245 baseline + 10 net new) on Python 3.13.
- `ruff check .` → clean.

Docs sync (SPEC.md version/deps/description-field wording) is in a separate PR.

https://claude.ai/code/session_01JLk9UQMmEkxTNfy4YDnRvZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLk9UQMmEkxTNfy4YDnRvZ)_