### PR TITLE
Update dependencies, move CI to Python 3.14, adapt to HA 2026.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.15.12
     hooks:
       # Run the linter
       - id: ruff

--- a/custom_components/ha_scheduler/calendar.py
+++ b/custom_components/ha_scheduler/calendar.py
@@ -63,7 +63,8 @@ async def async_setup_entry(
 class SchedulerCalendar(CalendarEntity):
     """Representation of a Scheduler calendar."""
 
-    _attr_has_entity_name = False
+    _attr_has_entity_name = True
+    _removed = False
 
     def __init__(
         self, entry: ConfigEntry, service_id: str, service_data: dict[str, Any]
@@ -85,7 +86,11 @@ class SchedulerCalendar(CalendarEntity):
         else:
             self._attr_unique_id = f"{entry.entry_id}_{service_id}"
 
-        self._attr_name = service_name
+        # With has_entity_name, a None name means the entity takes the device
+        # name, preserving the historical "calendar.<scheduler title>" id for
+        # single-service setups. Distinctly named services compose with the
+        # device name ("<scheduler title> <service name>").
+        self._attr_name = None if service_name == entry.title else service_name
 
         # Set device info to group calendars under the scheduler service
         self._attr_device_info = DeviceInfo(
@@ -97,9 +102,14 @@ class SchedulerCalendar(CalendarEntity):
 
     async def async_added_to_hass(self) -> None:
         """Register update listener when entity is added to hass."""
-        self._entry.async_on_unload(
+        self.async_on_remove(
             self._entry.add_update_listener(self._async_update_listener)
         )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Flag removal so in-flight update listeners stop early."""
+        self._removed = True
+        await super().async_will_remove_from_hass()
 
     async def _async_update_listener(
         self, hass: HomeAssistant, entry: ConfigEntry
@@ -113,6 +123,11 @@ class SchedulerCalendar(CalendarEntity):
                 current_year + CALENDAR_YEAR_LOOKAROUND + 1,
             ),
         )
+        # The await above can outlive this entity: if the entity was removed
+        # meanwhile, writing state would re-arm the calendar component's
+        # event-transition timers with nothing left to cancel them.
+        if self._removed:
+            return
         self.async_write_ha_state()
 
     def _get_schedules(self) -> list[dict[str, Any]]:

--- a/custom_components/ha_scheduler/manifest.json
+++ b/custom_components/ha_scheduler/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Smiley73/ha-scheduler/issues",
   "quality_scale": "gold",
-  "requirements": ["holidays>=0.93", "babel>=2.18.0"],
+  "requirements": ["holidays>=0.95", "babel>=2.18.0"],
   "version": "0.5.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 homeassistant>=2023.12.0
-holidays>=0.93
+holidays>=0.95
 babel>=2.18.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,11 +1,11 @@
 pytest>=9.0.0
-pytest-homeassistant-custom-component>=0.13.316
-pytest-cov>=7.0.0
-ruff>=0.15.2
+pytest-homeassistant-custom-component>=0.13.325
+pytest-cov>=7.1.0
+ruff>=0.15.12
 pre-commit>=4.5.1
 babel>=2.18.0
-holidays>=0.93
+holidays>=0.95
 # Fix for pycares/aiodns compatibility issue
 # Note: Versions must match homeassistant requirements
 pycares>=4.11.0
-aiodns>=3.5.0
+aiodns>=3.6.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,26 @@ local helpers. Existing tests retain local helpers for backwards compatibility.
 from __future__ import annotations
 
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ha_scheduler.const import DOMAIN
+
+
+@pytest.fixture(autouse=True)
+async def unload_entries_after_test(hass):
+    """Unload all scheduler config entries after each test.
+
+    Home Assistant's calendar component schedules state-transition alarms via
+    async_track_point_in_time; they are only cancelled when the entities are
+    removed. Without an explicit unload these timers linger past the test and
+    trip the strict cleanup verification in pytest-homeassistant-custom-component.
+    """
+    yield
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.state is ConfigEntryState.LOADED:
+            await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
 
 
 @pytest.fixture

--- a/tests/test_multi_service.py
+++ b/tests/test_multi_service.py
@@ -66,11 +66,15 @@ async def test_multi_service_creates_one_calendar_per_service(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    state_a = hass.states.get("calendar.service_a")
-    state_b = hass.states.get("calendar.service_b")
+    state_a = hass.states.get("calendar.multi_service_scheduler_service_a")
+    state_b = hass.states.get("calendar.multi_service_scheduler_service_b")
 
-    assert state_a is not None, "calendar.service_a entity not found"
-    assert state_b is not None, "calendar.service_b entity not found"
+    assert state_a is not None, (
+        "calendar.multi_service_scheduler_service_a entity not found"
+    )
+    assert state_b is not None, (
+        "calendar.multi_service_scheduler_service_b entity not found"
+    )
 
 
 async def test_multi_service_each_calendar_shows_own_schedules(
@@ -82,8 +86,12 @@ async def test_multi_service_each_calendar_shows_own_schedules(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    cal_a = hass.data["calendar"].get_entity("calendar.service_a")
-    cal_b = hass.data["calendar"].get_entity("calendar.service_b")
+    cal_a = hass.data["calendar"].get_entity(
+        "calendar.multi_service_scheduler_service_a"
+    )
+    cal_b = hass.data["calendar"].get_entity(
+        "calendar.multi_service_scheduler_service_b"
+    )
 
     assert cal_a is not None
     assert cal_b is not None
@@ -111,8 +119,12 @@ async def test_multi_service_default_has_entry_id_as_unique_id(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    cal_a = hass.data["calendar"].get_entity("calendar.service_a")
-    cal_b = hass.data["calendar"].get_entity("calendar.service_b")
+    cal_a = hass.data["calendar"].get_entity(
+        "calendar.multi_service_scheduler_service_a"
+    )
+    cal_b = hass.data["calendar"].get_entity(
+        "calendar.multi_service_scheduler_service_b"
+    )
 
     # Default service: unique_id == entry_id
     assert cal_a.unique_id == entry.entry_id
@@ -131,8 +143,12 @@ async def test_multi_service_default_configuration_is_per_service(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    cal_a = hass.data["calendar"].get_entity("calendar.service_a")
-    cal_b = hass.data["calendar"].get_entity("calendar.service_b")
+    cal_a = hass.data["calendar"].get_entity(
+        "calendar.multi_service_scheduler_service_a"
+    )
+    cal_b = hass.data["calendar"].get_entity(
+        "calendar.multi_service_scheduler_service_b"
+    )
 
     attrs_a = cal_a.extra_state_attributes
     attrs_b = cal_b.extra_state_attributes

--- a/tests/test_week_schedules.py
+++ b/tests/test_week_schedules.py
@@ -587,12 +587,12 @@ def test_partial_week_boundary_calculations():
         assert len(dates) == 1
 
         start_date, end_date = dates[0]
-        assert (
-            start_date == exp_start
-        ), f"Year {year}, month {month}, first_weekday {first_weekday}"
-        assert (
-            end_date == exp_end
-        ), f"Year {year}, month {month}, first_weekday {first_weekday}"
+        assert start_date == exp_start, (
+            f"Year {year}, month {month}, first_weekday {first_weekday}"
+        )
+        assert end_date == exp_end, (
+            f"Year {year}, month {month}, first_weekday {first_weekday}"
+        )
 
 
 def test_cross_month_week_schedules():


### PR DESCRIPTION
## Summary

Applies the version bumps proposed by Dependabot (#38–#42) in one reviewable change, and adapts the integration to the Home Assistant version the new test harness brings in.

### Dependency updates
- `holidays>=0.95` (requirements.txt, requirements_test.txt, **and manifest.json** — Dependabot doesn't touch the manifest)
- `pytest-homeassistant-custom-component>=0.13.325`
- `pytest-cov>=7.1.0`
- `ruff>=0.15.12` (requirements_test.txt **and the pre-commit rev**, so pre-commit and CI agree)
- `aiodns>=3.6.1`

### CI moves to Python 3.14
`pytest-homeassistant-custom-component` 0.13.317+ requires Python ≥3.14, so the lint and test workflows move from 3.13 to 3.14. This must land together with the dependency bump — merging #42 alone would break CI.

### Home Assistant 2026.6 compatibility
The new test harness pins HA 2026.6, which surfaced two behavior changes:

1. **Entity naming**: HA 2026.x prefixes the device name into entity IDs of newly registered entities. The calendar entity adopts the modern naming convention (`has_entity_name = True`): calendars named after the scheduler keep taking the device name (identical entity IDs and display names), while distinctly named services compose with the device name. **Existing installs keep their registered entity IDs** — the registry preserves them.
2. **Calendar alarm timers**: the calendar component now schedules state-transition alarms via `async_track_point_in_time`. The options update listener awaits holiday-cache priming before writing state; if the entity is removed during that await, the write would re-arm alarms nothing cancels. The listener now bails out after removal and is tied to the entity lifecycle via `async_on_remove`. Tests unload config entries after each test so the alarms are cleaned up deterministically.

### Verification
- Full suite run 10× consecutively on Python 3.14.5 with the new pins (HA 2026.6.2): **255/255 pass, no lingering-timer flakes** (previously flaky at ~50%).
- `ruff check` and `ruff format --check` clean.

Once merged, Dependabot will auto-close #38–#42 as satisfied.

https://claude.ai/code/session_01RmeMdo84oEfraFghFGsY3d

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmeMdo84oEfraFghFGsY3d)_