### PR TITLE
Harden CI workflows: permissions, action pinning, coverage floor

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -43,11 +46,11 @@ jobs:
 
       - name: Run tests with pytest
         run: |
-          pytest tests/ --cov=custom_components/ha_scheduler --cov-report=xml --cov-report=term
+          pytest tests/ --cov=custom_components/ha_scheduler --cov-report=xml --cov-report=term --cov-fail-under=80
 
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -16,10 +19,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: HACS Validation
-        uses: hacs/action@main
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
         with:
           category: integration
           ignore: brands
 
       - name: Hassfest Validation
-        uses: home-assistant/actions/hassfest@master
+        uses: home-assistant/actions/hassfest@d05c25388490cd662baef8495e1bc764c3386153 # master


### PR DESCRIPTION
## Summary

Hardens the GitHub Actions workflows, found during the security review.

- **Least-privilege permissions**: `lint.yml`, `test.yml`, and `validate.yml` now declare `permissions: contents: read`. Previously the default `GITHUB_TOKEN` carried write access in these workflows. (`codeql.yml` already had a permissions block.)
- **Pin mutable action refs**: `hacs/action@main` and `home-assistant/actions/hassfest@master` are branch references that can change underneath us (supply-chain exposure). They are now pinned to commit SHAs with a branch comment; Dependabot's `github-actions` ecosystem (already configured) keeps the SHAs updated. Version-tagged official actions (`actions/*@v6`, etc.) are left as tags.
- **codecov-action v6 → v7** (supersedes Dependabot #43), switching the deprecated `file` input to `files`.
- **Coverage floor**: pytest now runs with `--cov-fail-under=80` (current coverage: 86%) so coverage regressions fail CI.

### Verification
- All workflow YAML validated with a safe-load pass.
- Pinned SHAs match `git ls-remote` output for the documented branches.

https://claude.ai/code/session_01RmeMdo84oEfraFghFGsY3d

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmeMdo84oEfraFghFGsY3d)_