### PR TITLE
Enable ruff security and quality rules

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,15 +1,25 @@
 [lint]
 select = [
-    "E",  # pycodestyle
-    "F",  # pyflakes
-    "I",  # isort
+    "E",   # pycodestyle
+    "F",   # pyflakes
+    "I",   # isort
+    "S",   # flake8-bandit (security)
+    "B",   # flake8-bugbear
+    "BLE", # flake8-blind-except
+    "UP",  # pyupgrade
+    "RUF", # ruff-specific rules
 ]
 ignore = [
     "E501",  # Line too long - will address in future refactoring
 ]
 
 [lint.per-file-ignores]
-"tests/*" = ["E501"]
+"tests/*" = [
+    "E501",
+    "S101",   # asserts are expected in tests
+    "S110",   # try-except-pass is a legitimate pattern when probing behavior
+    "BLE001", # broad catches are fine when tests probe failure behavior
+]
 
 [format]
 indent-style = "space"

--- a/custom_components/ha_scheduler/config_flow.py
+++ b/custom_components/ha_scheduler/config_flow.py
@@ -652,8 +652,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 "start_day_of_week", default=str(defaults.get("start_day_of_week", ""))
             ): SelectSelector(
                 SelectSelectorConfig(
-                    options=[SelectOptionDict(value="", label="Whole week")]
-                    + _get_day_of_week_options(),
+                    options=[
+                        SelectOptionDict(value="", label="Whole week"),
+                        *_get_day_of_week_options(),
+                    ],
                     mode=SelectSelectorMode.DROPDOWN,
                 )
             ),
@@ -673,8 +675,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 "end_day_of_week", default=str(defaults.get("end_day_of_week", ""))
             ): SelectSelector(
                 SelectSelectorConfig(
-                    options=[SelectOptionDict(value="", label="Whole week")]
-                    + _get_day_of_week_options(),
+                    options=[
+                        SelectOptionDict(value="", label="Whole week"),
+                        *_get_day_of_week_options(),
+                    ],
                     mode=SelectSelectorMode.DROPDOWN,
                 )
             ),
@@ -813,8 +817,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             from .holiday_importer import get_supported_countries
 
             countries = await get_supported_countries()
-        except Exception as err:
-            _LOGGER.error("Failed to load holiday countries: %s", err)
+        except Exception:
+            _LOGGER.exception("Failed to load holiday countries")
             return self.async_abort(reason="import_error")
 
         if not countries:
@@ -864,10 +868,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             from .holiday_importer import get_available_categories
 
             categories = await get_available_categories(str(country_code))
-        except Exception as err:
-            _LOGGER.error(
-                "Failed to load holiday categories for %s: %s", country_code, err
-            )
+        except Exception:
+            _LOGGER.exception("Failed to load holiday categories for %s", country_code)
             return self.async_abort(reason="import_error")
 
         if not categories:
@@ -917,9 +919,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             holidays_data = await get_holidays_for_country(
                 str(country_code), [category]
             )
-        except Exception as err:
-            _LOGGER.error(
-                "Failed to load holidays for %s/%s: %s", country_code, category, err
+        except Exception:
+            _LOGGER.exception(
+                "Failed to load holidays for %s/%s", country_code, category
             )
             errors["base"] = "import_error"
 
@@ -1283,8 +1285,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     }
                 ),
             )
-        except Exception as e:
-            _LOGGER.error("Failed to load countries: %s", e)
+        except Exception:
+            _LOGGER.exception("Failed to load countries")
             return self.async_abort(reason="import_error")
 
     async def async_step_import_holidays_categories(
@@ -1328,8 +1330,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ),
                 description_placeholders={"country": self._holiday_data["country"]},
             )
-        except Exception as e:
-            _LOGGER.error("Failed to load categories: %s", e)
+        except Exception:
+            _LOGGER.exception("Failed to load categories")
             return self.async_abort(reason="import_error")
 
     async def async_step_import_holidays_select(
@@ -1429,8 +1431,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 }
             )
 
-        except Exception as e:
-            _LOGGER.error("Failed to get holidays: %s", e)
+        except Exception:
+            _LOGGER.exception("Failed to get holidays")
             return vol.Schema(
                 {
                     vol.Optional("holidays", default=[]): SelectSelector(

--- a/custom_components/ha_scheduler/diagnostics.py
+++ b/custom_components/ha_scheduler/diagnostics.py
@@ -272,14 +272,12 @@ def _calculate_future_dates(
                 "overlaps": overlaps,
             }
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - diagnostics must never fail; error is recorded in output
             _LOGGER.warning(
                 "Failed to calculate schedule dates for year %s: %s", year, str(e)
             )
             warnings_list_err: list[str] = future_data["warnings"]
-            warnings_list_err.append(
-                f"Failed to compute dates for year {year}: {str(e)}"
-            )
+            warnings_list_err.append(f"Failed to compute dates for year {year}: {e!s}")
             years_dict_err: dict[str, Any] = future_data["years"]
             years_dict_err[year_key] = {
                 "error": str(e),
@@ -344,7 +342,7 @@ def _check_year_overlaps(
                         }
                     )
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - diagnostics must never fail; error is recorded in output
                 _LOGGER.warning(
                     "Failed to check overlap with schedule %s for year %s: %s",
                     other_id,
@@ -365,7 +363,7 @@ def _check_year_overlaps(
                 "conflict_count": 0,
             }
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - diagnostics must never fail; error is recorded in output
         _LOGGER.warning("Failed to check overlaps for year %s: %s", year, str(e))
         return {
             "status": "error",

--- a/custom_components/ha_scheduler/holiday_importer.py
+++ b/custom_components/ha_scheduler/holiday_importer.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+from collections.abc import Iterable
 from datetime import date, timedelta
 from functools import lru_cache
 from types import ModuleType
-from typing import Any, Iterable
+from typing import Any
 
 from .const import (
     CALENDAR_YEAR_LOOKAROUND,
@@ -45,7 +46,8 @@ def format_date_localized(date_obj: date, locale_code: str | None = None) -> str
         _LOGGER.debug("Babel not available for date formatting: %s", e)
         # Fallback to Python's strftime
         return date_obj.strftime("%B %d")
-    except Exception as e:  # Catch UnknownLocaleError, ValueError, etc.
+    except Exception as e:  # noqa: BLE001 - graceful fallback around third-party library quirks
+        # Catches UnknownLocaleError, ValueError, etc.
         _LOGGER.debug("Could not format date with locale %s: %s", locale_code, e)
         # Fallback to Python's strftime
         return date_obj.strftime("%B %d")
@@ -79,7 +81,8 @@ def get_localized_country_name(
     except ImportError as e:
         _LOGGER.debug("Babel not available for country names: %s", e)
         return fallback_name or country_code.replace("_", " ").title()
-    except Exception as e:  # Catch UnknownLocaleError, ValueError, AttributeError, etc.
+    except Exception as e:  # noqa: BLE001 - graceful fallback around third-party library quirks
+        # Catches UnknownLocaleError, ValueError, AttributeError, etc.
         _LOGGER.debug(
             "Could not get localized name for country %s: %s", country_code, e
         )
@@ -91,8 +94,9 @@ def get_localized_country_name(
         en_locale = Locale("en")
         if country_code.upper() in en_locale.territories:
             return en_locale.territories[country_code.upper()]
-    except Exception:  # Any error including ImportError
-        pass
+    except Exception as e:  # noqa: BLE001 - graceful fallback around third-party library quirks
+        # Any error including ImportError
+        _LOGGER.debug("Could not look up territory name: %s", e)
 
     # Fallback to provided name or formatted country code
     return fallback_name or country_code.replace("_", " ").title()
@@ -235,7 +239,7 @@ def _get_named_holiday_dates_sync(
                 for holiday_date, current_name in country_holidays.items()
                 if str(current_name).casefold() == holiday_name.casefold()
             ]
-    except Exception as err:
+    except Exception as err:  # noqa: BLE001 - graceful fallback around third-party library quirks
         _LOGGER.debug(
             "Could not resolve holiday %s for %s/%s in %s: %s",
             holiday_name,
@@ -280,7 +284,8 @@ def _get_named_holiday_dates_sync(
                 if lang_dates:
                     named_dates = lang_dates
                     break
-            except Exception:
+            except Exception as err:  # noqa: BLE001 - graceful fallback around third-party library quirks
+                _LOGGER.debug("Language lookup failed for %s: %s", holiday_name, err)
                 continue
 
     return tuple(sorted(set(named_dates)))
@@ -409,14 +414,14 @@ def _get_supported_countries_sync() -> dict[str, str]:
                 country_name = get_localized_country_name(country_code, holidays_name)
                 country_dict[country_code] = country_name
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - graceful fallback around third-party library quirks
                 _LOGGER.debug("Could not get info for country %s: %s", country_code, e)
                 continue
 
         return dict(sorted(country_dict.items(), key=lambda x: x[1]))
 
-    except Exception as e:
-        _LOGGER.error("Failed to get supported countries: %s", e)
+    except Exception:
+        _LOGGER.exception("Failed to get supported countries")
         # Fallback to basic list if dynamic discovery fails
         return {
             "US": "United States",
@@ -476,7 +481,7 @@ def _get_available_categories_sync(country_code: str) -> dict[str, str]:
                     if len(test_holidays) > 0:
                         category_name = category.replace("_", " ").title()
                         available_categories[category] = category_name
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 - graceful fallback around third-party library quirks
                     _LOGGER.debug(
                         "Category %s not supported for %s: %s",
                         category,
@@ -491,8 +496,8 @@ def _get_available_categories_sync(country_code: str) -> dict[str, str]:
 
         return available_categories
 
-    except Exception as e:
-        _LOGGER.error("Failed to get categories for %s: %s", country_code, e)
+    except Exception:
+        _LOGGER.exception("Failed to get categories for %s", country_code)
         return {"public": "Public Holidays"}
 
 
@@ -551,7 +556,7 @@ def _get_holidays_for_country_sync(
                                 }
                             all_holidays[holiday_name]["dates"].append(holiday_date)
 
-                    except Exception as e:
+                    except Exception as e:  # noqa: BLE001 - graceful fallback around third-party library quirks
                         _LOGGER.debug(
                             "Could not get %s holidays for %s in %s: %s",
                             category,
@@ -561,7 +566,7 @@ def _get_holidays_for_country_sync(
                         )
                         continue
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - graceful fallback around third-party library quirks
                 _LOGGER.debug(
                     "Category %s not supported for %s: %s", category, country_code, e
                 )
@@ -606,8 +611,8 @@ def _get_holidays_for_country_sync(
 
         return all_holidays
 
-    except Exception as e:
-        _LOGGER.error("Failed to get holidays for %s: %s", country_code, e)
+    except Exception:
+        _LOGGER.exception("Failed to get holidays for %s", country_code)
         return {}
 
 
@@ -824,5 +829,5 @@ def calculate_occurrence(target_date: date) -> int | None:
 
         return occurrence
 
-    except Exception:
+    except Exception:  # noqa: BLE001 - graceful fallback around third-party library quirks
         return None

--- a/custom_components/ha_scheduler/migrations.py
+++ b/custom_components/ha_scheduler/migrations.py
@@ -92,6 +92,6 @@ async def async_migrate_v1_to_v2(hass: HomeAssistant, entry: ConfigEntry) -> boo
 
         return True
 
-    except Exception as err:
-        _LOGGER.error("Failed to migrate config entry: %s", err)
+    except Exception:
+        _LOGGER.exception("Failed to migrate config entry")
         return False

--- a/custom_components/ha_scheduler/migrations.py
+++ b/custom_components/ha_scheduler/migrations.py
@@ -11,6 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # Current version - increment when adding new migrations
 CURRENT_VERSION = 2
+CURRENT_MINOR_VERSION = 1
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -23,15 +24,15 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         version,
         minor_version,
         CURRENT_VERSION,
-        1,
+        CURRENT_MINOR_VERSION,
     )
 
     # Migration from version 1 to 2 (helper to service transformation)
     if version == 1:
         if not await async_migrate_v1_to_v2(hass, entry):
             return False
-        version = 2
-        minor_version = 1
+        version = CURRENT_VERSION
+        minor_version = CURRENT_MINOR_VERSION
 
     # Update version numbers
     if version != entry.version or minor_version != entry.minor_version:

--- a/custom_components/ha_scheduler/schedule_generator.py
+++ b/custom_components/ha_scheduler/schedule_generator.py
@@ -106,7 +106,7 @@ def get_country_first_weekday(country_code: str | None = None) -> int:
         _LOGGER.debug("Babel not available for weekday detection: %s", e)
         return _get_fallback_weekday(country_code, country_upper)
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - see comment below
         # Catch Babel's UnknownLocaleError (direct Exception subclass), ValueError,
         # AttributeError, TypeError, and any other locale-related errors
         # Note: We use broad Exception here because babel.core.UnknownLocaleError
@@ -119,7 +119,7 @@ def get_country_first_weekday(country_code: str | None = None) -> int:
             locale = Locale.parse(country_code.lower())
             first_day = locale.first_week_day
             return first_day
-        except Exception:
+        except Exception:  # noqa: BLE001, S110 - last-resort fallback below
             # Any locale-related error in fallback - use mapping or default
             pass
 

--- a/tests/test_add_schedule_flow.py
+++ b/tests/test_add_schedule_flow.py
@@ -84,7 +84,7 @@ async def test_complete_add_date_schedule_flow(hass: HomeAssistant) -> None:
     print(f"Number of schedules: {len(schedules)}")
 
     assert len(schedules) == 1
-    schedule = list(schedules.values())[0]
+    schedule = next(iter(schedules.values()))
     assert schedule["name"] == "Test Schedule"
     assert schedule["schedule_type"] == "date"
     assert schedule["start_month"] == 6

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -95,7 +95,7 @@ async def test_options_flow_add_date_schedule(
     # Verify schedule was added
     schedules = get_schedules_from_entry(entry)
     assert len(schedules) == 1
-    schedule = list(schedules.values())[0]
+    schedule = next(iter(schedules.values()))
     assert schedule["name"] == "Summer Schedule"
     assert schedule["schedule_type"] == "date"
     assert schedule["start_month"] == 6
@@ -139,7 +139,7 @@ async def test_options_flow_add_week_schedule(
 
     schedules = get_schedules_from_entry(entry)
     assert len(schedules) == 1
-    schedule = list(schedules.values())[0]
+    schedule = next(iter(schedules.values()))
     assert schedule["name"] == "Week Schedule"
     assert schedule["schedule_type"] == "week"
 
@@ -218,7 +218,7 @@ async def test_options_flow_add_nth_day_schedule(
 
     schedules = get_schedules_from_entry(entry)
     assert len(schedules) == 1
-    schedule = list(schedules.values())[0]
+    schedule = next(iter(schedules.values()))
     assert schedule["name"] == "Nth Day Schedule"
     assert schedule["schedule_type"] == "nth-day"
     assert schedule["start_offset"] == 2
@@ -298,7 +298,7 @@ async def test_options_flow_add_holiday_schedule(
 
     schedules = get_schedules_from_entry(entry)
     assert len(schedules) == 1
-    schedule = list(schedules.values())[0]
+    schedule = next(iter(schedules.values()))
     assert schedule["name"] == "Good Friday"
     assert schedule["schedule_type"] == "holiday"
     assert schedule["country_code"] == "DE"
@@ -2136,7 +2136,7 @@ async def test_options_flow_add_date_schedule_with_configuration(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     schedules = get_schedules_from_entry(entry)
-    schedule = list(schedules.values())[0]
+    schedule = next(iter(schedules.values()))
     assert schedule["configuration"] == {"color": "red", "brightness": 75}
 
 
@@ -2235,7 +2235,7 @@ async def test_options_flow_list_configuration_accepted(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     schedules = get_schedules_from_entry(entry)
-    schedule = list(schedules.values())[0]
+    schedule = next(iter(schedules.values()))
     assert schedule["configuration"] == ["one", "two"]
 
 
@@ -2309,7 +2309,7 @@ async def test_options_flow_explicit_empty_dict_configuration_stored(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     schedules = get_schedules_from_entry(entry)
-    schedule = list(schedules.values())[0]
+    schedule = next(iter(schedules.values()))
     assert "configuration" in schedule
     assert schedule["configuration"] == {}
 
@@ -2348,7 +2348,7 @@ async def test_options_flow_add_week_schedule_whole_week_no_types(
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     schedules = get_schedules_from_entry(entry)
-    schedule = list(schedules.values())[0]
+    schedule = next(iter(schedules.values()))
     assert schedule["start_week"] == 1
     assert schedule["end_week"] == 4
     assert "start_week_type" not in schedule

--- a/tests/test_end_to_end_integration.py
+++ b/tests/test_end_to_end_integration.py
@@ -60,7 +60,7 @@ class TestIntegrationScenarios:
         # Verify schedule preserved
         assert "schedules" in default_service
         assert len(default_service["schedules"]) == 1
-        migrated_schedule = list(default_service["schedules"].values())[0]
+        migrated_schedule = next(iter(default_service["schedules"].values()))
         assert migrated_schedule["name"] == "Old Schedule"
         assert migrated_schedule["start_month"] == 6
 

--- a/tests/test_holiday_import_comprehensive.py
+++ b/tests/test_holiday_import_comprehensive.py
@@ -240,7 +240,7 @@ class TestHolidayImportDefaults:
             schedules = updated_entry.options["services"]["default"]["schedules"]
 
             assert len(schedules) == 1
-            schedule = list(schedules.values())[0]
+            schedule = next(iter(schedules.values()))
             assert schedule["name"] == "Independence Day"  # No "(US)" suffix
             assert schedule["schedule_type"] == "holiday"
             assert schedule["country_code"] == "US"
@@ -314,7 +314,7 @@ class TestHolidayImportDefaults:
         schedules = updated_entry.options["services"]["default"]["schedules"]
 
         assert len(schedules) == 1
-        schedule = list(schedules.values())[0]
+        schedule = next(iter(schedules.values()))
         assert schedule["name"] == "Good Friday"
         assert schedule["schedule_type"] == "holiday"
         assert schedule["country_code"] == "DE"
@@ -387,7 +387,7 @@ class TestHolidayImportDefaults:
         schedules = updated_entry.options["services"]["default"]["schedules"]
 
         assert len(schedules) == 1
-        schedule = list(schedules.values())[0]
+        schedule = next(iter(schedules.values()))
         assert schedule["name"] == "Independence Day"
         assert schedule["schedule_type"] == "holiday"
         assert schedule["country_code"] == "US"
@@ -468,7 +468,7 @@ class TestHolidayImportOptions:
             schedules = updated_entry.options["services"]["default"]["schedules"]
 
             assert len(schedules) == 1
-            schedule = list(schedules.values())[0]
+            schedule = next(iter(schedules.values()))
             assert schedule["name"] == "Independence Day (US)"
 
     async def test_holiday_import_overwrite_existing(
@@ -1325,7 +1325,7 @@ class TestHolidayImportErrorHandling:
         schedules = updated_entry.options["services"]["default"]["schedules"]
         assert len(schedules) == 1
 
-        schedule = list(schedules.values())[0]
+        schedule = next(iter(schedules.values()))
         assert schedule["name"] == "Invalid Holiday"
         assert schedule["schedule_type"] == "holiday"
         assert schedule["country_code"] == "US"

--- a/tests/test_holiday_importer_functions.py
+++ b/tests/test_holiday_importer_functions.py
@@ -31,7 +31,7 @@ def test_holiday_importer_defers_holidays_import_until_runtime(monkeypatch):
     original_module = sys.modules[module_name]
     original_import = builtins.__import__
 
-    def guard_holidays_import(name, globals=None, locals=None, fromlist=(), level=0):  # noqa: A002
+    def guard_holidays_import(name, globals=None, locals=None, fromlist=(), level=0):
         if name == "holidays":
             raise AssertionError("holidays imported during module load")
         return original_import(name, globals, locals, fromlist, level)

--- a/tests/test_schedule_generator_edge_cases.py
+++ b/tests/test_schedule_generator_edge_cases.py
@@ -190,7 +190,7 @@ def test_check_overlap_edge_cases() -> None:
     }
 
     # Overlapping schedules
-    has_overlap, conflicting_name = check_overlap(schedule1, [schedule2])
+    has_overlap, _conflicting_name = check_overlap(schedule1, [schedule2])
     assert has_overlap is True
 
     # Non-overlapping schedules
@@ -203,7 +203,7 @@ def test_check_overlap_edge_cases() -> None:
         "uid": "schedule3",
     }
 
-    has_overlap, conflicting_name = check_overlap(schedule1, [schedule3])
+    has_overlap, _conflicting_name = check_overlap(schedule1, [schedule3])
     assert has_overlap is False
 
 

--- a/tests/test_schedule_persistence.py
+++ b/tests/test_schedule_persistence.py
@@ -54,7 +54,7 @@ async def test_single_schedule_persists(
     # Verify schedule is in config entry
     schedules = get_schedules_from_entry(entry)
     assert len(schedules) == 1
-    schedule = list(schedules.values())[0]
+    schedule = next(iter(schedules.values()))
     assert schedule["name"] == "Test Schedule"
     assert schedule["schedule_type"] == "date"
 
@@ -151,7 +151,7 @@ async def test_schedule_with_configuration_persists(
     # Verify configuration is saved
     schedules = get_schedules_from_entry(entry)
     assert len(schedules) == 1
-    schedule = list(schedules.values())[0]
+    schedule = next(iter(schedules.values()))
     assert "configuration" in schedule
     assert schedule["configuration"]["summary"] == "Custom Event"
     assert schedule["configuration"]["description"] == "Test Description"

--- a/tests/test_week_schedules.py
+++ b/tests/test_week_schedules.py
@@ -587,12 +587,12 @@ def test_partial_week_boundary_calculations():
         assert len(dates) == 1
 
         start_date, end_date = dates[0]
-        assert (
-            start_date == exp_start
-        ), f"Year {year}, month {month}, first_weekday {first_weekday}"
-        assert (
-            end_date == exp_end
-        ), f"Year {year}, month {month}, first_weekday {first_weekday}"
+        assert start_date == exp_start, (
+            f"Year {year}, month {month}, first_weekday {first_weekday}"
+        )
+        assert end_date == exp_end, (
+            f"Year {year}, month {month}, first_weekday {first_weekday}"
+        )
 
 
 def test_cross_month_week_schedules():


### PR DESCRIPTION
## Summary

Extends the ruff rule set with security and quality rules, and fixes the resulting findings.

### New rules
`S` (flake8-bandit security checks), `B` (bugbear), `BLE` (blind except), `UP` (pyupgrade), `RUF` (ruff-specific). Tests additionally allow `S101` (asserts), `S110`/`BLE001` (probing failure behavior is legitimate in tests).

### Code fixes
- **Tracebacks preserved**: catch-all handlers that logged via `_LOGGER.error("...: %s", err)` now use `_LOGGER.exception(...)` — config flow holiday loading, holiday importer fallback paths, and the config entry migration wrapper.
- **Intentional broad catches annotated**: diagnostics collectors (must never fail; errors are recorded in the diagnostics output) and graceful fallbacks around Babel/`holidays` library quirks carry `noqa: BLE001` with the reason.
- **Silent handlers now log**: territory-name lookup and language-aware holiday resolution previously swallowed exceptions with `pass`/`continue`; they log at debug level.
- **Mechanical autofixes** (reviewed): `next(iter(...))` over `[0]` slices, iterable unpacking, `collections.abc` imports, f-string conversion.
- Migration logging: introduce `CURRENT_MINOR_VERSION` so the debug message logs the real target version instead of a hardcoded `1`.

### Verification
- `ruff check .` and `ruff format --check .` clean.
- Full test suite passes (255/255) on the current CI environment (Python 3.13, HA 2026.2).

Independent of the other remediation PRs; merges in any order.

https://claude.ai/code/session_01RmeMdo84oEfraFghFGsY3d

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmeMdo84oEfraFghFGsY3d)_