### PR TITLE
Code consistency: HA timezone everywhere, schedule-type constants, DST tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       # Run pytest on all tests
       - id: pytest-check
         name: pytest-check
-        entry: bash -c 'source .venv/bin/activate && python -m pytest tests/ -q'
+        entry: python -m pytest tests/ -q
         language: system
         pass_filenames: false
         always_run: true

--- a/custom_components/ha_scheduler/calendar.py
+++ b/custom_components/ha_scheduler/calendar.py
@@ -143,6 +143,8 @@ class SchedulerCalendar(CalendarEntity):
                 date_ranges = generate_schedule_dates(schedule, year)
 
                 for schedule_start, schedule_end in date_ranges:
+                    # All-day events use date objects; CalendarEvent.end is
+                    # exclusive, so add one day to include the end date.
                     event = CalendarEvent(
                         start=schedule_start,
                         end=schedule_end + timedelta(days=1),
@@ -222,6 +224,8 @@ class SchedulerCalendar(CalendarEntity):
                 for schedule_start, schedule_end in date_ranges:
                     # Only include if it overlaps with requested range
                     if schedule_start <= end_day and schedule_end >= start_day:
+                        # All-day events use date objects; CalendarEvent.end is
+                        # exclusive, so add one day to include the end date.
                         events.append(
                             CalendarEvent(
                                 start=schedule_start,

--- a/custom_components/ha_scheduler/config_flow.py
+++ b/custom_components/ha_scheduler/config_flow.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import date
 from typing import Any
 
 import voluptuous as vol
@@ -22,8 +21,17 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
     TemplateSelector,
 )
+from homeassistant.util import dt as dt_util
 
-from .const import DAY_NAMES, DOMAIN, MONTH_NAMES
+from .const import (
+    DAY_NAMES,
+    DOMAIN,
+    MONTH_NAMES,
+    SCHEDULE_TYPE_DATE,
+    SCHEDULE_TYPE_HOLIDAY,
+    SCHEDULE_TYPE_NTH_DAY,
+    SCHEDULE_TYPE_WEEK,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,20 +65,20 @@ def _get_occurrence_options() -> list[SelectOptionDict]:
 def _get_schedule_type_options() -> list[SelectOptionDict]:
     """Get options for schedule type selection."""
     return [
-        SelectOptionDict(value="date", label="By Date"),
-        SelectOptionDict(value="week", label="By Week of Month"),
-        SelectOptionDict(value="nth-day", label="By Nth Day of Month"),
-        SelectOptionDict(value="holiday", label="By Holiday"),
+        SelectOptionDict(value=SCHEDULE_TYPE_DATE, label="By Date"),
+        SelectOptionDict(value=SCHEDULE_TYPE_WEEK, label="By Week of Month"),
+        SelectOptionDict(value=SCHEDULE_TYPE_NTH_DAY, label="By Nth Day of Month"),
+        SelectOptionDict(value=SCHEDULE_TYPE_HOLIDAY, label="By Holiday"),
     ]
 
 
 def _get_schedule_type_display(schedule_type: str) -> str:
     """Return a display label for a schedule type."""
     display_names = {
-        "date": "By Date",
-        "week": "By Week of Month",
-        "nth-day": "By Nth Day of Month",
-        "holiday": "By Holiday",
+        SCHEDULE_TYPE_DATE: "By Date",
+        SCHEDULE_TYPE_WEEK: "By Week of Month",
+        SCHEDULE_TYPE_NTH_DAY: "By Nth Day of Month",
+        SCHEDULE_TYPE_HOLIDAY: "By Holiday",
     }
     return display_names.get(schedule_type, schedule_type)
 
@@ -303,7 +311,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         errors: dict[str, str] = {}
         self._overlap_conflicting_name = None
 
-        current_year = date.today().year
+        current_year = dt_util.now().date().year
         await async_prime_holiday_cache(
             [data, *schedules.values()],
             range(current_year, current_year + HOLIDAY_OVERLAP_HORIZON + 1),
@@ -328,6 +336,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 exclude_uid=self._schedule_id
                 if self._schedule_id in schedules
                 else None,
+                today=dt_util.now().date(),
             )
 
             if has_overlap:
@@ -344,7 +353,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def _validate_week_schedule(self, data: dict[str, Any]) -> dict[str, str]:
         """Validate that a week schedule produces a valid recurring range."""
-        if data.get("schedule_type") != "week":
+        if data.get("schedule_type") != SCHEDULE_TYPE_WEEK:
             return {}
 
         from .schedule_generator import week_schedule_has_valid_ranges
@@ -377,11 +386,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self._schedule_data = {"schedule_type": user_input["schedule_type"]}
             self._schedule_id = str(uuid.uuid4())
 
-            if user_input["schedule_type"] == "date":
+            if user_input["schedule_type"] == SCHEDULE_TYPE_DATE:
                 return await self.async_step_configure_date()
-            if user_input["schedule_type"] == "week":
+            if user_input["schedule_type"] == SCHEDULE_TYPE_WEEK:
                 return await self.async_step_configure_week()
-            if user_input["schedule_type"] == "holiday":
+            if user_input["schedule_type"] == SCHEDULE_TYPE_HOLIDAY:
                 return await self.async_step_configure_holiday_country()
             return await self.async_step_configure_nth_day()
 
@@ -389,7 +398,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             step_id="add_schedule",
             data_schema=vol.Schema(
                 {
-                    vol.Required("schedule_type", default="date"): SelectSelector(
+                    vol.Required(
+                        "schedule_type", default=SCHEDULE_TYPE_DATE
+                    ): SelectSelector(
                         SelectSelectorConfig(
                             options=_get_schedule_type_options(),
                             mode=SelectSelectorMode.DROPDOWN,
@@ -411,7 +422,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 # Convert string values to integers
                 data = {
                     "name": user_input["name"],
-                    "schedule_type": "date",
+                    "schedule_type": SCHEDULE_TYPE_DATE,
                     "start_month": int(user_input["start_month"]),
                     "start_day": int(user_input["start_day"]),
                     "end_month": int(user_input["end_month"]),
@@ -531,7 +542,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
                 data = {
                     "name": user_input["name"],
-                    "schedule_type": "week",
+                    "schedule_type": SCHEDULE_TYPE_WEEK,
                     "start_month": int(user_input["start_month"]),
                     "start_week": start_week,
                     "end_month": int(user_input["end_month"]),
@@ -702,7 +713,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             try:
                 data = {
                     "name": user_input["name"],
-                    "schedule_type": "nth-day",
+                    "schedule_type": SCHEDULE_TYPE_NTH_DAY,
                     "month": int(user_input["month"]),
                     "occurrence": int(user_input["occurrence"]),
                     "day_of_week": int(user_input["day_of_week"]),
@@ -915,7 +926,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             from .holiday_importer import get_holidays_for_country
 
             holidays_data = await get_holidays_for_country(
-                str(country_code), [category]
+                str(country_code), [category], today=dt_util.now().date()
             )
         except Exception as err:
             _LOGGER.error(
@@ -933,7 +944,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
                 data = {
                     "name": user_input["name"],
-                    "schedule_type": "holiday",
+                    "schedule_type": SCHEDULE_TYPE_HOLIDAY,
                     "country_code": str(country_code),
                     "category": str(category),
                     "holiday_name": holiday_name,
@@ -1050,11 +1061,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     sort_keys=False,
                 ).strip()
 
-            if schedule["schedule_type"] == "date":
+            if schedule["schedule_type"] == SCHEDULE_TYPE_DATE:
                 return await self.async_step_configure_date()
-            if schedule["schedule_type"] == "week":
+            if schedule["schedule_type"] == SCHEDULE_TYPE_WEEK:
                 return await self.async_step_configure_week()
-            if schedule["schedule_type"] == "holiday":
+            if schedule["schedule_type"] == SCHEDULE_TYPE_HOLIDAY:
                 return await self.async_step_configure_holiday_country()
             return await self.async_step_configure_nth_day()
 
@@ -1390,7 +1401,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     }
                 )
 
-            holidays_data = await get_holidays_for_country(country, categories)
+            holidays_data = await get_holidays_for_country(
+                country, categories, today=dt_util.now().date()
+            )
 
             _LOGGER.debug(
                 "Got %d holidays for country %s, categories %s",
@@ -1462,7 +1475,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             if not country:
                 return self.async_abort(reason="import_error")
 
-            all_holidays = await get_holidays_for_country(country, categories)
+            all_holidays = await get_holidays_for_country(
+                country, categories, today=dt_util.now().date()
+            )
 
             # Get current schedules
             schedules = self._get_service_schedules()
@@ -1540,7 +1555,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         continue
 
                 existing_schedules_list = get_schedules_with_uids()
-                current_year = date.today().year
+                current_year = dt_util.now().date().year
                 await async_prime_holiday_cache(
                     [schedule, *existing_schedules_list],
                     range(current_year, current_year + HOLIDAY_OVERLAP_HORIZON + 1),
@@ -1549,6 +1564,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     schedule,
                     existing_schedules_list,
                     exclude_uid=excluded_uid,
+                    today=dt_util.now().date(),
                 )
 
                 if has_overlap and skip_on_overlap:

--- a/custom_components/ha_scheduler/const.py
+++ b/custom_components/ha_scheduler/const.py
@@ -2,6 +2,12 @@
 
 DOMAIN = "ha_scheduler"
 
+# Schedule type identifiers (stored values in config entry options)
+SCHEDULE_TYPE_DATE = "date"
+SCHEDULE_TYPE_WEEK = "week"
+SCHEDULE_TYPE_NTH_DAY = "nth-day"
+SCHEDULE_TYPE_HOLIDAY = "holiday"
+
 # How many years before/after today to include when generating calendar events
 CALENDAR_YEAR_LOOKAROUND = 3
 

--- a/custom_components/ha_scheduler/diagnostics.py
+++ b/custom_components/ha_scheduler/diagnostics.py
@@ -3,14 +3,20 @@
 from __future__ import annotations
 
 import logging
-from datetime import date
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
-from .const import DAY_NAMES
+from .const import (
+    DAY_NAMES,
+    SCHEDULE_TYPE_DATE,
+    SCHEDULE_TYPE_HOLIDAY,
+    SCHEDULE_TYPE_NTH_DAY,
+    SCHEDULE_TYPE_WEEK,
+)
 from .holiday_importer import async_prime_holiday_cache
 from .schedule_generator import generate_schedule_dates
 
@@ -66,7 +72,7 @@ async def async_get_config_entry_diagnostics(
             }
         }
 
-    current_year = date.today().year
+    current_year = dt_util.now().date().year
     all_schedules = [
         schedule
         for service_data in services.values()
@@ -130,7 +136,7 @@ def _build_schedule_info(
     }
 
     # Add type-specific fields
-    if schedule_data.get("schedule_type") == "date":
+    if schedule_data.get("schedule_type") == SCHEDULE_TYPE_DATE:
         schedule_info.update(
             {
                 "start_month": schedule_data.get("start_month"),
@@ -139,7 +145,7 @@ def _build_schedule_info(
                 "end_day": schedule_data.get("end_day"),
             }
         )
-    elif schedule_data.get("schedule_type") == "week":
+    elif schedule_data.get("schedule_type") == SCHEDULE_TYPE_WEEK:
         start_day_of_week = schedule_data.get("start_day_of_week")
         end_day_of_week = schedule_data.get("end_day_of_week")
         start_week_type = schedule_data.get("start_week_type", "partial")
@@ -173,7 +179,7 @@ def _build_schedule_info(
                 "country_code": schedule_data.get("country_code"),
             }
         )
-    elif schedule_data.get("schedule_type") == "nth-day":
+    elif schedule_data.get("schedule_type") == SCHEDULE_TYPE_NTH_DAY:
         day_of_week = schedule_data.get("day_of_week")
         schedule_info.update(
             {
@@ -185,7 +191,7 @@ def _build_schedule_info(
                 "end_offset": schedule_data.get("end_offset"),
             }
         )
-    elif schedule_data.get("schedule_type") == "holiday":
+    elif schedule_data.get("schedule_type") == SCHEDULE_TYPE_HOLIDAY:
         schedule_info.update(
             {
                 "country_code": schedule_data.get("country_code"),
@@ -231,7 +237,7 @@ def _calculate_future_dates(
     Returns:
         Dictionary with yearly data, overlap information, and any computation warnings.
     """
-    current_year = date.today().year
+    current_year = dt_util.now().date().year
     future_data: dict[str, Any] = {"years": {}, "warnings": []}
 
     for year in range(current_year, current_year + 3):

--- a/custom_components/ha_scheduler/holiday_importer.py
+++ b/custom_components/ha_scheduler/holiday_importer.py
@@ -15,6 +15,10 @@ from .const import (
     DAY_NAMES_DISPLAY,
     MONTH_NAMES_DISPLAY,
     OCCURRENCE_NAMES_DISPLAY,
+    SCHEDULE_TYPE_DATE,
+    SCHEDULE_TYPE_HOLIDAY,
+    SCHEDULE_TYPE_NTH_DAY,
+    SCHEDULE_TYPE_WEEK,
 )
 
 # Babel imports moved inside functions to avoid blocking I/O during module import
@@ -147,7 +151,7 @@ def _build_holiday_cache_requests(
     requests: set[tuple[str, str | None, str, str, int]] = set()
 
     for schedule in schedules:
-        if schedule.get("schedule_type") != "holiday":
+        if schedule.get("schedule_type") != SCHEDULE_TYPE_HOLIDAY:
             continue
 
         try:
@@ -349,7 +353,7 @@ def _should_use_holiday_schedule_pattern(pattern: dict[str, Any] | None) -> bool
     if pattern is None:
         return False
 
-    return pattern.get("schedule_type") == "date" and str(
+    return pattern.get("schedule_type") == SCHEDULE_TYPE_DATE and str(
         pattern.get("description", "")
     ).startswith("Variable date")
 
@@ -359,7 +363,7 @@ def build_holiday_schedule_pattern(
 ) -> dict[str, Any]:
     """Build a holiday-backed pattern for import flows."""
     return {
-        "schedule_type": "holiday",
+        "schedule_type": SCHEDULE_TYPE_HOLIDAY,
         "country_code": country_code.upper(),
         "category": category,
         "holiday_name": holiday_name,
@@ -505,9 +509,16 @@ async def get_available_categories(country_code: str) -> dict[str, str]:
 
 
 def _get_holidays_for_country_sync(
-    country_code: str, categories: list[str] | None = None
+    country_code: str,
+    categories: list[str] | None = None,
+    today: date | None = None,
 ) -> dict[str, dict[str, Any]]:
-    """Get all holidays for a country with their patterns (sync version)."""
+    """Get all holidays for a country with their patterns (sync version).
+
+    ``today`` anchors the year window used for pattern analysis. Callers
+    inside Home Assistant should pass ``dt_util.now().date()`` so the
+    configured timezone is honored; defaults to the system date.
+    """
     if not _holidays_available():
         return {}
 
@@ -518,7 +529,7 @@ def _get_holidays_for_country_sync(
         all_holidays: dict[str, dict[str, Any]] = {}
 
         # Get holidays for multiple years to analyze patterns
-        today = date.today()
+        today = today or date.today()
         years = list(
             range(
                 today.year - CALENDAR_YEAR_LOOKAROUND,
@@ -590,7 +601,7 @@ def _get_holidays_for_country_sync(
                 if dates:
                     first_date = dates[0]
                     pattern = {
-                        "schedule_type": "date",
+                        "schedule_type": SCHEDULE_TYPE_DATE,
                         "start_month": first_date.month,
                         "start_day": first_date.day,
                         "end_month": first_date.month,
@@ -612,12 +623,18 @@ def _get_holidays_for_country_sync(
 
 
 async def get_holidays_for_country(
-    country_code: str, categories: list[str] | None = None
+    country_code: str,
+    categories: list[str] | None = None,
+    today: date | None = None,
 ) -> dict[str, dict[str, Any]]:
-    """Get all holidays for a country with their patterns."""
+    """Get all holidays for a country with their patterns.
+
+    ``today`` anchors the year window used for pattern analysis; see
+    ``_get_holidays_for_country_sync``.
+    """
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(
-        None, _get_holidays_for_country_sync, country_code, categories
+        None, _get_holidays_for_country_sync, country_code, categories, today
     )
 
 
@@ -630,7 +647,7 @@ def analyze_holiday_pattern(dates: list[date]) -> dict[str, Any] | None:
     if len(dates) == 1:
         date_obj = dates[0]
         return {
-            "schedule_type": "date",
+            "schedule_type": SCHEDULE_TYPE_DATE,
             "start_month": date_obj.month,
             "start_day": date_obj.day,
             "end_month": date_obj.month,
@@ -645,7 +662,7 @@ def analyze_holiday_pattern(dates: list[date]) -> dict[str, Any] | None:
     if all(d.month == dates[0].month and d.day == dates[0].day for d in dates):
         # Fixed date pattern (e.g., July 4th, Christmas)
         return {
-            "schedule_type": "date",
+            "schedule_type": SCHEDULE_TYPE_DATE,
             "start_month": dates[0].month,
             "start_day": dates[0].day,
             "end_month": dates[0].month,
@@ -675,7 +692,7 @@ def analyze_holiday_pattern(dates: list[date]) -> dict[str, Any] | None:
                     return week_pattern
 
                 return {
-                    "schedule_type": "nth-day",
+                    "schedule_type": SCHEDULE_TYPE_NTH_DAY,
                     "month": month,
                     "occurrence": occurrence,
                     "day_of_week": day_of_week,
@@ -691,7 +708,7 @@ def analyze_holiday_pattern(dates: list[date]) -> dict[str, Any] | None:
 
         # If we can't determine a clear pattern, default to first occurrence as date
         return {
-            "schedule_type": "date",
+            "schedule_type": SCHEDULE_TYPE_DATE,
             "start_month": first_date.month,
             "start_day": first_date.day,
             "end_month": first_date.month,
@@ -763,7 +780,7 @@ def _analyze_week_pattern(dates: list[date]) -> dict[str, Any] | None:
                     if consistent:
                         # Create week-based schedule with appropriate week types
                         schedule = {
-                            "schedule_type": "week",
+                            "schedule_type": SCHEDULE_TYPE_WEEK,
                             "start_month": first_date.month,
                             "start_week": start_occurrence,
                             "start_day_of_week": first_date.weekday(),

--- a/custom_components/ha_scheduler/schedule_generator.py
+++ b/custom_components/ha_scheduler/schedule_generator.py
@@ -8,6 +8,13 @@ from datetime import date, timedelta
 from functools import lru_cache
 from typing import Any
 
+from .const import (
+    SCHEDULE_TYPE_DATE,
+    SCHEDULE_TYPE_HOLIDAY,
+    SCHEDULE_TYPE_NTH_DAY,
+    SCHEDULE_TYPE_WEEK,
+)
+
 # Babel imports moved inside functions to avoid blocking I/O during module import
 
 _LOGGER = logging.getLogger(__name__)
@@ -138,15 +145,15 @@ def generate_schedule_dates(
 
     This function recalculates the actual dates for the specified year.
     """
-    schedule_type = schedule.get("schedule_type", "date")
+    schedule_type = schedule.get("schedule_type", SCHEDULE_TYPE_DATE)
 
-    if schedule_type == "date":
+    if schedule_type == SCHEDULE_TYPE_DATE:
         return _generate_by_date(schedule, year)
-    if schedule_type == "week":
+    if schedule_type == SCHEDULE_TYPE_WEEK:
         return _generate_by_week(schedule, year)
-    if schedule_type == "nth-day":
+    if schedule_type == SCHEDULE_TYPE_NTH_DAY:
         return _generate_by_nth_day(schedule, year)
-    if schedule_type == "holiday":
+    if schedule_type == SCHEDULE_TYPE_HOLIDAY:
         return _generate_by_holiday(schedule, year)
 
     return []
@@ -438,7 +445,7 @@ def _generate_by_week(schedule: dict[str, Any], year: int) -> list[tuple[date, d
 
 def week_schedule_has_valid_ranges(schedule: dict[str, Any]) -> bool:
     """Return whether a week schedule generates a valid range every year."""
-    if schedule.get("schedule_type") != "week":
+    if schedule.get("schedule_type") != SCHEDULE_TYPE_WEEK:
         return False
 
     return _week_schedule_has_valid_ranges(_get_overlap_signature(schedule))
@@ -750,12 +757,21 @@ def check_overlap(
     schedule: dict[str, Any],
     existing_schedules: list[dict[str, Any]],
     exclude_uid: str | None = None,
+    today: date | None = None,
 ) -> tuple[bool, str | None]:
     """Check if a schedule overlaps with existing schedules.
 
     Gregorian schedules are validated across a full 400-year cycle to keep
     overlap checks deterministic. Holiday-backed schedules use a bounded,
     provider-backed horizon because their dates come from the holidays library.
+
+    Args:
+        schedule: Schedule to validate.
+        existing_schedules: Schedules to validate against.
+        exclude_uid: Schedule uid to skip (when editing an existing schedule).
+        today: Reference date for the holiday-overlap horizon. Callers inside
+            Home Assistant should pass ``dt_util.now().date()`` so the
+            configured timezone is honored; defaults to the system date.
 
     Returns:
         Tuple of (has_overlap, conflicting_schedule_name)
@@ -787,7 +803,7 @@ def check_overlap(
             if not existing_dates:
                 continue
         else:
-            overlap_years = _get_overlap_years(schedule, existing)
+            overlap_years = _get_overlap_years(schedule, existing, today)
             new_dates = tuple(_generate_dates_for_years(schedule, overlap_years))
             if not new_dates:
                 continue
@@ -809,7 +825,7 @@ def _get_overlap_signature(schedule: dict[str, Any]) -> OverlapSignature:
     """Return the date-relevant schedule fields as a stable cache key."""
     schedule_type = schedule.get("schedule_type")
 
-    if schedule_type == "date":
+    if schedule_type == SCHEDULE_TYPE_DATE:
         return (
             "date",
             schedule.get("start_month"),
@@ -818,7 +834,7 @@ def _get_overlap_signature(schedule: dict[str, Any]) -> OverlapSignature:
             schedule.get("end_day"),
         )
 
-    if schedule_type == "week":
+    if schedule_type == SCHEDULE_TYPE_WEEK:
         country_code = schedule.get("country_code")
         normalized_country = (
             country_code.upper() if isinstance(country_code, str) else None
@@ -836,7 +852,7 @@ def _get_overlap_signature(schedule: dict[str, Any]) -> OverlapSignature:
             normalized_country,
         )
 
-    if schedule_type == "nth-day":
+    if schedule_type == SCHEDULE_TYPE_NTH_DAY:
         return (
             "nth-day",
             schedule.get("month"),
@@ -846,7 +862,7 @@ def _get_overlap_signature(schedule: dict[str, Any]) -> OverlapSignature:
             schedule.get("end_offset", 0),
         )
 
-    if schedule_type == "holiday":
+    if schedule_type == SCHEDULE_TYPE_HOLIDAY:
         country_code = schedule.get("country_code")
         normalized_country = (
             country_code.upper() if isinstance(country_code, str) else None
@@ -873,17 +889,17 @@ def _schedule_from_signature(signature: OverlapSignature) -> dict[str, Any] | No
 
     schedule_type = signature[0]
 
-    if schedule_type == "date":
+    if schedule_type == SCHEDULE_TYPE_DATE:
         _, start_month, start_day, end_month, end_day = signature
         return {
-            "schedule_type": "date",
+            "schedule_type": SCHEDULE_TYPE_DATE,
             "start_month": start_month,
             "start_day": start_day,
             "end_month": end_month,
             "end_day": end_day,
         }
 
-    if schedule_type == "week":
+    if schedule_type == SCHEDULE_TYPE_WEEK:
         (
             _,
             start_month,
@@ -897,7 +913,7 @@ def _schedule_from_signature(signature: OverlapSignature) -> dict[str, Any] | No
             country_code,
         ) = signature
         schedule = {
-            "schedule_type": "week",
+            "schedule_type": SCHEDULE_TYPE_WEEK,
             "start_month": start_month,
             "start_week": start_week,
             "end_month": end_month,
@@ -913,10 +929,10 @@ def _schedule_from_signature(signature: OverlapSignature) -> dict[str, Any] | No
             schedule["country_code"] = country_code
         return schedule
 
-    if schedule_type == "nth-day":
+    if schedule_type == SCHEDULE_TYPE_NTH_DAY:
         _, month, occurrence, day_of_week, start_offset, end_offset = signature
         return {
-            "schedule_type": "nth-day",
+            "schedule_type": SCHEDULE_TYPE_NTH_DAY,
             "month": month,
             "occurrence": occurrence,
             "day_of_week": day_of_week,
@@ -924,7 +940,7 @@ def _schedule_from_signature(signature: OverlapSignature) -> dict[str, Any] | No
             "end_offset": end_offset,
         }
 
-    if schedule_type == "holiday":
+    if schedule_type == SCHEDULE_TYPE_HOLIDAY:
         (
             _,
             country_code,
@@ -935,7 +951,7 @@ def _schedule_from_signature(signature: OverlapSignature) -> dict[str, Any] | No
             end_offset,
         ) = signature
         schedule = {
-            "schedule_type": "holiday",
+            "schedule_type": SCHEDULE_TYPE_HOLIDAY,
             "country_code": country_code,
             "holiday_name": holiday_name,
             "name_lookup": lookup,
@@ -997,14 +1013,16 @@ def _uses_deterministic_overlap_cycle(signature: OverlapSignature) -> bool:
 
 
 def _get_overlap_years(
-    schedule: dict[str, Any], existing_schedule: dict[str, Any]
+    schedule: dict[str, Any],
+    existing_schedule: dict[str, Any],
+    today: date | None = None,
 ) -> range:
     """Return the bounded year range used for holiday-backed overlap checks."""
-    current_year = date.today().year
+    current_year = (today or date.today()).year
 
     if (
-        schedule.get("schedule_type") == "holiday"
-        or existing_schedule.get("schedule_type") == "holiday"
+        schedule.get("schedule_type") == SCHEDULE_TYPE_HOLIDAY
+        or existing_schedule.get("schedule_type") == SCHEDULE_TYPE_HOLIDAY
     ):
         return range(current_year, current_year + HOLIDAY_OVERLAP_HORIZON + 1)
 

--- a/tests/test_schedule_generator_edge_cases.py
+++ b/tests/test_schedule_generator_edge_cases.py
@@ -286,3 +286,87 @@ def test_schedule_generator_robustness() -> None:
     except (TypeError, ValueError):
         # Expected if no type conversion is done
         pass
+
+
+def test_date_schedule_across_spring_dst_boundary() -> None:
+    """Schedule date math is calendar-based and unaffected by spring DST."""
+    # US DST 2026: clocks spring forward on March 8.
+    schedule = {
+        "schedule_type": "date",
+        "start_month": 3,
+        "start_day": 7,
+        "end_month": 3,
+        "end_day": 9,
+        "uid": "dst-spring",
+    }
+
+    dates = generate_schedule_dates(schedule, 2026)
+    assert dates == [(date(2026, 3, 7), date(2026, 3, 9))]
+
+
+def test_date_schedule_across_fall_dst_boundary() -> None:
+    """Schedule date math is calendar-based and unaffected by fall DST."""
+    # US DST 2026: clocks fall back on November 1.
+    schedule = {
+        "schedule_type": "date",
+        "start_month": 10,
+        "start_day": 31,
+        "end_month": 11,
+        "end_day": 2,
+        "uid": "dst-fall",
+    }
+
+    dates = generate_schedule_dates(schedule, 2026)
+    assert dates == [(date(2026, 10, 31), date(2026, 11, 2))]
+
+
+def test_week_schedule_across_dst_boundary() -> None:
+    """Week-of-month schedules spanning a DST transition keep whole days."""
+    # Second week of March 2026 contains the March 8 spring-forward.
+    schedule = {
+        "schedule_type": "week",
+        "start_month": 3,
+        "start_week": 1,  # second week
+        "end_month": 3,
+        "end_week": 1,
+        "uid": "dst-week",
+    }
+
+    dates = generate_schedule_dates(schedule, 2026)
+    assert len(dates) == 1
+    start, end = dates[0]
+    # The range must cover March 8 fully and span whole days.
+    assert start <= date(2026, 3, 8) <= end
+    assert (end - start).days == 6
+
+
+def test_check_overlap_accepts_today_reference_date() -> None:
+    """check_overlap accepts an explicit reference date for its horizon."""
+    schedule1 = {
+        "schedule_type": "date",
+        "start_month": 6,
+        "start_day": 1,
+        "end_month": 6,
+        "end_day": 30,
+        "name": "June",
+        "uid": "june",
+    }
+    schedule2 = {
+        "schedule_type": "date",
+        "start_month": 6,
+        "start_day": 15,
+        "end_month": 7,
+        "end_day": 15,
+        "name": "Summer",
+        "uid": "summer",
+    }
+
+    has_overlap, conflicting = check_overlap(
+        schedule1, [schedule2], today=date(2026, 1, 1)
+    )
+    assert has_overlap is True
+    assert conflicting == "Summer"
+
+    has_overlap, conflicting = check_overlap(schedule1, [], today=date(2026, 1, 1))
+    assert has_overlap is False
+    assert conflicting is None

--- a/tests/test_week_schedules.py
+++ b/tests/test_week_schedules.py
@@ -587,12 +587,12 @@ def test_partial_week_boundary_calculations():
         assert len(dates) == 1
 
         start_date, end_date = dates[0]
-        assert (
-            start_date == exp_start
-        ), f"Year {year}, month {month}, first_weekday {first_weekday}"
-        assert (
-            end_date == exp_end
-        ), f"Year {year}, month {month}, first_weekday {first_weekday}"
+        assert start_date == exp_start, (
+            f"Year {year}, month {month}, first_weekday {first_weekday}"
+        )
+        assert end_date == exp_end, (
+            f"Year {year}, month {month}, first_weekday {first_weekday}"
+        )
 
 
 def test_cross_month_week_schedules():


### PR DESCRIPTION
## Summary

Code-consistency fixes and test coverage gaps from the review.

- **Timezone source**: `config_flow.py` and `diagnostics.py` now use `dt_util.now().date()` (Home Assistant's configured timezone) instead of `date.today()` (system timezone), matching `calendar.py`. Near midnight these can disagree and pick the wrong day/year. The HA-independent modules (`schedule_generator.py`, `holiday_importer.py`) stay free of `homeassistant` imports: `check_overlap()` and `get_holidays_for_country()` gain an optional `today` parameter that HA-side callers populate.
- **Schedule-type constants**: the `"date"` / `"week"` / `"nth-day"` / `"holiday"` literals (45 occurrences across four modules) move to `const.py` as `SCHEDULE_TYPE_*` constants. Stored option values are unchanged — no migration needed.
- **Calendar comments**: document the exclusive-end convention behind `end + timedelta(days=1)` so the correct all-day-event math doesn't get "fixed" later.
- **Pre-commit hook**: the pytest hook no longer hardcodes `source .venv/bin/activate`; it runs `python -m pytest` in whatever environment pre-commit runs in.
- **New tests**: DST spring-forward/fall-back boundary tests (locking in that schedule date math is calendar-based and timezone-independent) and coverage for the new `today` parameter.

### Verification
- Full test suite: 259/259 pass (255 existing + 4 new) on the current CI environment.
- `ruff check .` and `ruff format --check .` clean.

Independent of the other remediation PRs; merges in any order.

https://claude.ai/code/session_01RmeMdo84oEfraFghFGsY3d

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmeMdo84oEfraFghFGsY3d)_