### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/custom_components/ha_scheduler/manifest.json
+++ b/custom_components/ha_scheduler/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/Smiley73/ha-scheduler/issues",
   "quality_scale": "gold",
   "requirements": ["holidays>=0.95", "babel>=2.18.0"],
-  "version": "0.5.0"
+  "version": "0.5.1"
 }


### PR DESCRIPTION
## Summary
- Bumps the integration version to 0.5.1 in `manifest.json`

## Test plan
- [ ] Verify `manifest.json` version is `0.5.1`
- [ ] Confirm no functional changes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)