### PR TITLE
Prevent one bad holiday schedule from blanking the entire calendar

### DIFF
--- a/custom_components/ha_scheduler/calendar.py
+++ b/custom_components/ha_scheduler/calendar.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import date, datetime, timedelta
 from typing import Any
 
@@ -17,6 +18,8 @@ from .holiday_importer import async_prime_holiday_cache
 from .schedule_generator import generate_schedule_dates
 
 PARALLEL_UPDATES = 0
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -130,11 +133,22 @@ class SchedulerCalendar(CalendarEntity):
             return
         self.async_write_ha_state()
 
+    def _get_service_data(self) -> dict[str, Any]:
+        """Return live service data, handling both new and legacy layouts."""
+        services = self._entry.options.get("services", {})
+        if services:
+            return services.get(self._service_id, {})
+
+        # Legacy (pre-services) entries store schedules at the options root.
+        return {
+            "name": self._entry.title,
+            "schedules": self._entry.options.get("schedules", {}),
+            "configuration": self._entry.options.get("configuration", {}),
+        }
+
     def _get_schedules(self) -> list[dict[str, Any]]:
         """Get schedules from config entry options for this service."""
-        services = self._entry.options.get("services", {})
-        service_data = services.get(self._service_id, {})
-        schedules_dict = service_data.get("schedules", {})
+        schedules_dict = self._get_service_data().get("schedules", {})
         return [
             schedule if "uid" in schedule else {**schedule, "uid": schedule_id}
             for schedule_id, schedule in schedules_dict.items()
@@ -150,27 +164,34 @@ class SchedulerCalendar(CalendarEntity):
         future_events: list[tuple[date, CalendarEvent, dict[str, Any]]] = []
 
         for schedule in self._get_schedules():
-            # Check surrounding years to catch schedules that wrap across year boundaries
-            for year in range(
-                current_year - CALENDAR_YEAR_LOOKAROUND,
-                current_year + CALENDAR_YEAR_LOOKAROUND + 1,
-            ):
-                date_ranges = generate_schedule_dates(schedule, year)
+            try:
+                # Check surrounding years to catch schedules that wrap across year boundaries
+                for year in range(
+                    current_year - CALENDAR_YEAR_LOOKAROUND,
+                    current_year + CALENDAR_YEAR_LOOKAROUND + 1,
+                ):
+                    date_ranges = generate_schedule_dates(schedule, year)
 
-                for schedule_start, schedule_end in date_ranges:
-                    # All-day events use date objects; CalendarEvent.end is
-                    # exclusive, so add one day to include the end date.
-                    event = CalendarEvent(
-                        start=schedule_start,
-                        end=schedule_end + timedelta(days=1),
-                        summary=schedule["name"],
-                        uid=f"{schedule['uid']}_{year}",
-                        description="",
-                    )
-                    if schedule_start <= today <= schedule_end:
-                        active_events.append((event.start, event, schedule))
-                    elif schedule_start > today:
-                        future_events.append((event.start, event, schedule))
+                    for schedule_start, schedule_end in date_ranges:
+                        # All-day events use date objects; CalendarEvent.end is
+                        # exclusive, so add one day to include the end date.
+                        event = CalendarEvent(
+                            start=schedule_start,
+                            end=schedule_end + timedelta(days=1),
+                            summary=schedule["name"],
+                            uid=f"{schedule['uid']}_{year}",
+                            description="",
+                        )
+                        if schedule_start <= today <= schedule_end:
+                            active_events.append((event.start, event, schedule))
+                        elif schedule_start > today:
+                            future_events.append((event.start, event, schedule))
+            except Exception:  # noqa: BLE001 - one bad schedule must not hide the others
+                _LOGGER.warning(
+                    "Skipping schedule %r while determining the current event",
+                    schedule.get("name", schedule.get("uid")),
+                    exc_info=True,
+                )
 
         candidates = active_events or future_events
         if not candidates:
@@ -183,9 +204,7 @@ class SchedulerCalendar(CalendarEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return entity specific state attributes."""
-        services = self._entry.options.get("services", {})
-        service_data = services.get(self._service_id, {})
-        default_config = service_data.get("configuration", {})
+        default_config = self._get_service_data().get("configuration", {})
 
         # Surface the schedule configuration for the active event, or the
         # next upcoming event when the calendar is currently idle.
@@ -232,23 +251,30 @@ class SchedulerCalendar(CalendarEntity):
         await async_prime_holiday_cache(schedules, range(start_year - 1, end_year + 1))
 
         for schedule in schedules:
-            # Include previous year to catch year-wrapping schedules
-            for year in range(start_year - 1, end_year + 1):
-                date_ranges = generate_schedule_dates(schedule, year)
+            try:
+                # Include previous year to catch year-wrapping schedules
+                for year in range(start_year - 1, end_year + 1):
+                    date_ranges = generate_schedule_dates(schedule, year)
 
-                for schedule_start, schedule_end in date_ranges:
-                    # Only include if it overlaps with requested range
-                    if schedule_start <= end_day and schedule_end >= start_day:
-                        # All-day events use date objects; CalendarEvent.end is
-                        # exclusive, so add one day to include the end date.
-                        events.append(
-                            CalendarEvent(
-                                start=schedule_start,
-                                end=schedule_end + timedelta(days=1),
-                                summary=schedule["name"],
-                                uid=f"{schedule['uid']}_{year}",
-                                description="",
+                    for schedule_start, schedule_end in date_ranges:
+                        # Only include if it overlaps with requested range
+                        if schedule_start <= end_day and schedule_end >= start_day:
+                            # All-day events use date objects; CalendarEvent.end is
+                            # exclusive, so add one day to include the end date.
+                            events.append(
+                                CalendarEvent(
+                                    start=schedule_start,
+                                    end=schedule_end + timedelta(days=1),
+                                    summary=schedule["name"],
+                                    uid=f"{schedule['uid']}_{year}",
+                                    description="",
+                                )
                             )
-                        )
+            except Exception:  # noqa: BLE001 - one bad schedule must not hide the others
+                _LOGGER.warning(
+                    "Skipping schedule %r while listing calendar events",
+                    schedule.get("name", schedule.get("uid")),
+                    exc_info=True,
+                )
 
         return sorted(events, key=lambda x: x.start)

--- a/custom_components/ha_scheduler/diagnostics.py
+++ b/custom_components/ha_scheduler/diagnostics.py
@@ -17,7 +17,7 @@ from .const import (
     SCHEDULE_TYPE_NTH_DAY,
     SCHEDULE_TYPE_WEEK,
 )
-from .holiday_importer import async_prime_holiday_cache
+from .holiday_importer import async_prime_holiday_cache, get_holidays_library_version
 from .schedule_generator import generate_schedule_dates
 
 # Keys that may contain sensitive user data in YAML configuration blobs
@@ -116,6 +116,11 @@ async def async_get_config_entry_diagnostics(
             "title": entry.title,
             "entry_id": entry.entry_id,
             "scheduler_name": entry.data.get("scheduler_name", entry.title),
+        },
+        "environment": {
+            "holidays_version": await hass.async_add_executor_job(
+                get_holidays_library_version
+            ),
         },
         "services": services_diagnostics,
         "summary": {

--- a/custom_components/ha_scheduler/holiday_importer.py
+++ b/custom_components/ha_scheduler/holiday_importer.py
@@ -134,6 +134,14 @@ def _holidays_available() -> bool:
     return HOLIDAYS_AVAILABLE
 
 
+def get_holidays_library_version() -> str | None:
+    """Return the installed holidays library version, if available."""
+    holidays_module = _get_holidays_module()
+    if holidays_module is None:
+        return None
+    return getattr(holidays_module, "__version__", None)
+
+
 def _clear_holiday_caches() -> None:
     """Clear cached holiday metadata for tests."""
     global HOLIDAYS_AVAILABLE
@@ -184,9 +192,19 @@ def _prime_holiday_cache_sync(
 ) -> None:
     """Warm the holiday lookup cache for a set of named holiday requests."""
     for country_code, category, holiday_name, lookup, year in requests:
-        _get_named_holiday_dates_sync(
-            country_code, category, holiday_name, lookup, year
-        )
+        try:
+            _get_named_holiday_dates_sync(
+                country_code, category, holiday_name, lookup, year
+            )
+        except Exception as err:  # noqa: BLE001 - cache priming must never fail the caller
+            _LOGGER.warning(
+                "Could not prime holiday cache for %s/%s %r in %s: %s",
+                country_code,
+                category or "public",
+                holiday_name,
+                year,
+                err,
+            )
 
 
 async def async_prime_holiday_cache(
@@ -213,12 +231,26 @@ def _get_country_holidays_sync(
     if holidays_module is None:
         return None
 
-    if category and category != "public":
-        return holidays_module.country_holidays(
-            country_code, categories=category, years=year
-        )
+    # The holidays library raises NotImplementedError for unknown countries and
+    # ValueError for unsupported categories; both can occur for stored schedules
+    # once a different library version is installed. One bad schedule must not
+    # propagate and take down calendar setup or event listing for the rest.
+    try:
+        if category and category != "public":
+            return holidays_module.country_holidays(
+                country_code, categories=category, years=year
+            )
 
-    return holidays_module.country_holidays(country_code, years=year)
+        return holidays_module.country_holidays(country_code, years=year)
+    except Exception as err:  # noqa: BLE001 - graceful fallback around third-party library quirks
+        _LOGGER.warning(
+            "Holiday provider rejected country %s (category %s) for %s: %s",
+            country_code,
+            category or "public",
+            year,
+            err,
+        )
+        return None
 
 
 @lru_cache(maxsize=4096)
@@ -291,6 +323,35 @@ def _get_named_holiday_dates_sync(
             except Exception as err:  # noqa: BLE001 - graceful fallback around third-party library quirks
                 _LOGGER.debug("Language lookup failed for %s: %s", holiday_name, err)
                 continue
+
+    if not named_dates:
+        if lookup != "icontains":
+            # The library may have renamed the holiday since the schedule was
+            # stored (e.g. "Thanksgiving" became "Thanksgiving Day" in v0.93).
+            # Retry with a contains-style match before giving up.
+            fallback_dates = _get_named_holiday_dates_sync(
+                country_code, category, holiday_name, "icontains", year
+            )
+            if fallback_dates:
+                _LOGGER.info(
+                    "Holiday %r for %s/%s in %s only matched with a contains "
+                    "lookup; the installed holidays library may have renamed it",
+                    holiday_name,
+                    country_code,
+                    category or "public",
+                    year,
+                )
+            return fallback_dates
+
+        _LOGGER.warning(
+            "Holiday %r could not be resolved for %s/%s in %s; the stored name "
+            "may no longer exist in the installed holidays library",
+            holiday_name,
+            country_code,
+            category or "public",
+            year,
+        )
+        return ()
 
     return tuple(sorted(set(named_dates)))
 

--- a/tests/test_calendar_resilience.py
+++ b/tests/test_calendar_resilience.py
@@ -1,0 +1,231 @@
+"""Tests that one broken schedule cannot blank the whole calendar.
+
+The holidays library raises NotImplementedError for unknown countries and
+ValueError for categories it no longer supports — both can legitimately end up
+in stored options when the installed holidays version changes underneath an
+existing config entry. The calendar must keep serving the remaining schedules.
+"""
+
+from datetime import date, datetime
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from custom_components.ha_scheduler.holiday_importer import _clear_holiday_caches
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+@pytest.fixture(autouse=True)
+def clear_holiday_caches():
+    """Reset holiday resolver caches between tests.
+
+    The resolver warns once per cached lookup; without a reset, a lookup cached
+    by an earlier test would suppress the warning a later test asserts on.
+    """
+    _clear_holiday_caches()
+    yield
+    _clear_holiday_caches()
+
+
+BROKEN_HOLIDAY_SCHEDULES = {
+    "unknown-country": {
+        "name": "Unknown Country Holiday",
+        "schedule_type": "holiday",
+        "country_code": "XX",
+        "category": "public",
+        "holiday_name": "Some Holiday",
+        "name_lookup": "iexact",
+        "start_offset": 0,
+        "end_offset": 0,
+        "uid": "unknown-country",
+    },
+    "unsupported-category": {
+        "name": "Unsupported Category Holiday",
+        "schedule_type": "holiday",
+        "country_code": "US",
+        "category": "bank",
+        "holiday_name": "Christmas Day",
+        "name_lookup": "iexact",
+        "start_offset": 0,
+        "end_offset": 0,
+        "uid": "unsupported-category",
+    },
+}
+
+
+@pytest.mark.parametrize("broken_id", list(BROKEN_HOLIDAY_SCHEDULES))
+async def test_broken_holiday_schedule_does_not_blank_calendar(
+    hass: HomeAssistant, create_service_entry, broken_id: str
+) -> None:
+    """A holiday schedule the library rejects must not hide other schedules."""
+    schedules = {
+        "date-schedule": {
+            "name": "Summer Schedule",
+            "schedule_type": "date",
+            "start_month": 6,
+            "start_day": 1,
+            "end_month": 8,
+            "end_day": 31,
+            "uid": "date-schedule",
+        },
+        broken_id: BROKEN_HOLIDAY_SCHEDULES[broken_id],
+    }
+    entry = create_service_entry(schedules=schedules)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("calendar.test_scheduler")
+    assert state is not None
+    assert state.state != "unavailable"
+
+    calendar = hass.data["calendar"].get_entity("calendar.test_scheduler")
+    start = datetime(2024, 5, 1, tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    end = datetime(2024, 9, 30, tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    events = await calendar.async_get_events(hass, start, end)
+
+    assert len(events) == 1
+    assert events[0].summary == "Summer Schedule"
+    assert events[0].start == date(2024, 6, 1)
+
+
+async def test_broken_holiday_schedule_logs_warning(
+    hass: HomeAssistant,
+    create_service_entry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Rejected holiday providers surface as warnings, not silent debug noise."""
+    entry = create_service_entry(
+        schedules={"unknown-country": BROKEN_HOLIDAY_SCHEDULES["unknown-country"]}
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert any(
+        record.levelname == "WARNING" and "XX" in record.message
+        for record in caplog.records
+    )
+
+
+async def test_renamed_holiday_falls_back_to_contains_lookup(
+    hass: HomeAssistant, create_service_entry
+) -> None:
+    """A stored name the library has since renamed still resolves.
+
+    holidays >= 0.93 renamed e.g. "Thanksgiving" to "Thanksgiving Day"; the
+    exact-match lookup finds nothing, so resolution must fall back to a
+    contains-style match before giving up.
+    """
+    schedules = {
+        "thanksgiving": {
+            "name": "Thanksgiving",
+            "schedule_type": "holiday",
+            "country_code": "US",
+            "category": "public",
+            "holiday_name": "Thanksgiving",
+            "name_lookup": "iexact",
+            "start_offset": 0,
+            "end_offset": 0,
+            "uid": "thanksgiving",
+        }
+    }
+    entry = create_service_entry(schedules=schedules)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    calendar = hass.data["calendar"].get_entity("calendar.test_scheduler")
+    start = datetime(2026, 11, 1, tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    end = datetime(2026, 11, 30, tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    events = await calendar.async_get_events(hass, start, end)
+
+    assert len(events) == 1
+    assert events[0].summary == "Thanksgiving"
+    # Thanksgiving Day 2026 is November 26
+    assert events[0].start == date(2026, 11, 26)
+
+
+async def test_legacy_options_layout_still_lists_events(
+    hass: HomeAssistant,
+) -> None:
+    """An entry with the pre-services options layout still serves its events.
+
+    The setup path builds a default service for legacy options, but event
+    listing reads live options — it must fall back to the legacy keys instead
+    of returning an empty calendar.
+    """
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.ha_scheduler.const import DOMAIN
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test Scheduler",
+        data={"scheduler_name": "Test Scheduler"},
+        options={
+            "schedules": {
+                "date-schedule": {
+                    "name": "Summer Schedule",
+                    "schedule_type": "date",
+                    "start_month": 6,
+                    "start_day": 1,
+                    "end_month": 8,
+                    "end_day": 31,
+                    "uid": "date-schedule",
+                }
+            },
+            "configuration": {},
+        },
+        version=2,
+        minor_version=1,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    calendar = hass.data["calendar"].get_entity("calendar.test_scheduler")
+    start = datetime(2024, 5, 1, tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    end = datetime(2024, 9, 30, tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    events = await calendar.async_get_events(hass, start, end)
+
+    assert len(events) == 1
+    assert events[0].summary == "Summer Schedule"
+
+
+async def test_unresolvable_holiday_logs_warning(
+    hass: HomeAssistant,
+    create_service_entry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A holiday name that resolves to zero dates is reported at warning level."""
+    schedules = {
+        "ghost-holiday": {
+            "name": "Ghost Holiday",
+            "schedule_type": "holiday",
+            "country_code": "US",
+            "category": "public",
+            "holiday_name": "Definitely Not A Real Holiday",
+            "name_lookup": "iexact",
+            "start_offset": 0,
+            "end_offset": 0,
+            "uid": "ghost-holiday",
+        }
+    }
+    entry = create_service_entry(schedules=schedules)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert any(
+        record.levelname == "WARNING"
+        and "Definitely Not A Real Holiday" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Problem

On a production instance, the HA Calendar dashboard showed **no events at all** — including manual date/week/nth-day schedules that never touch the holidays library.

Root cause: `holidays.country_holidays()` raises `NotImplementedError` for unknown countries and `ValueError` for categories the installed library version no longer supports. Both can legitimately occur for stored schedules once a different holidays version is installed. The provider creation in `_get_country_holidays_sync` was unguarded, so a single bad holiday schedule propagated through `async_prime_holiday_cache` and aborted **calendar platform setup** and **`async_get_events`** — hiding every schedule of every type ("Error while setting up ha_scheduler platform for calendar").

A second, silent failure mode compounds it: the holidays library renames holidays across versions (e.g. `"Thanksgiving"` → `"Thanksgiving Day"` in v0.93), so stored names with the `iexact` lookup resolve to zero dates with only a debug-level log.

## Changes

- **Guard provider creation**: `_get_country_holidays_sync` catches library rejections, logs a warning, and resolves to no dates instead of raising.
- **Per-schedule isolation**: `async_get_events` and the current-event lookup skip a failing schedule with a warning instead of dropping the whole response; cache priming can no longer fail its caller.
- **Rename fallback**: when an exact holiday-name lookup (plus the existing language retries) finds nothing, retry with a contains lookup; names that still resolve to zero dates are logged at **warning** level so they're visible in default logs.
- **Legacy options layout**: `_get_schedules` falls back to the pre-`services` options keys instead of serving a permanently empty calendar for unmigrated entries.
- **Diagnostics**: report the installed holidays library version.

## Testing

- New regression tests in `tests/test_calendar_resilience.py` (6 tests): broken country/category schedules don't blank the calendar or platform setup, warnings are emitted, renamed holidays resolve via fallback, legacy layout still lists events. All fail without the fix.
- Full suite: 265 passed, against holidays 0.98 (manifest requires >=0.95; the dev venv previously tested 0.93).

🤖 Generated with [Claude Code](https://claude.com/claude-code)