### PR TITLE
Fix calendar dashboard breakage from CalendarEntity method collision

### DIFF
--- a/custom_components/ha_scheduler/calendar.py
+++ b/custom_components/ha_scheduler/calendar.py
@@ -15,11 +15,22 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CALENDAR_YEAR_LOOKAROUND, DOMAIN
 from .holiday_importer import async_prime_holiday_cache
-from .schedule_generator import generate_schedule_dates
+from .schedule_generator import generate_schedule_dates, get_country_first_weekday
 
 PARALLEL_UPDATES = 0
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _prime_locale_cache(schedules: list[dict[str, Any]]) -> None:
+    """Load Babel locale data for week schedules (blocking; run in executor).
+
+    Babel reads its locale data files from disk on first use; resolving each
+    country once here lets later event-loop lookups hit Babel's in-memory cache.
+    """
+    for schedule in schedules:
+        if schedule.get("schedule_type") == "week":
+            get_country_first_weekday(schedule.get("country_code"))
 
 
 async def async_setup_entry(
@@ -59,6 +70,7 @@ async def async_setup_entry(
             current_year + CALENDAR_YEAR_LOOKAROUND + 1,
         ),
     )
+    await hass.async_add_executor_job(_prime_locale_cache, all_schedules)
 
     async_add_entities(calendars, True)
 
@@ -106,7 +118,7 @@ class SchedulerCalendar(CalendarEntity):
     async def async_added_to_hass(self) -> None:
         """Register update listener when entity is added to hass."""
         self.async_on_remove(
-            self._entry.add_update_listener(self._async_update_listener)
+            self._entry.add_update_listener(self._async_options_updated)
         )
 
     async def async_will_remove_from_hass(self) -> None:
@@ -114,18 +126,26 @@ class SchedulerCalendar(CalendarEntity):
         self._removed = True
         await super().async_will_remove_from_hass()
 
-    async def _async_update_listener(
+    async def _async_options_updated(
         self, hass: HomeAssistant, entry: ConfigEntry
     ) -> None:
-        """Handle options update."""
+        """Handle options update.
+
+        Must not be called _async_update_listener: CalendarEntity defines a
+        method of that name (HA 2026.6+) which the calendar dashboard's event
+        subscription invokes, and shadowing it with this signature breaks
+        every dashboard subscription for the entity.
+        """
         current_year = dt_util.now().date().year
+        schedules = self._get_schedules()
         await async_prime_holiday_cache(
-            self._get_schedules(),
+            schedules,
             range(
                 current_year - CALENDAR_YEAR_LOOKAROUND,
                 current_year + CALENDAR_YEAR_LOOKAROUND + 1,
             ),
         )
+        await hass.async_add_executor_job(_prime_locale_cache, schedules)
         # The await above can outlive this entity: if the entity was removed
         # meanwhile, writing state would re-arm the calendar component's
         # event-transition timers with nothing left to cancel them.

--- a/tests/test_calendar_edge_cases.py
+++ b/tests/test_calendar_edge_cases.py
@@ -498,7 +498,7 @@ async def test_calendar_update_listener(hass: HomeAssistant) -> None:
     calendar.async_write_ha_state = Mock()
 
     # Trigger update listener
-    await calendar._async_update_listener(hass, entry)
+    await calendar._async_options_updated(hass, entry)
 
     # Verify state update was called
     calendar.async_write_ha_state.assert_called_once()

--- a/tests/test_calendar_resilience.py
+++ b/tests/test_calendar_resilience.py
@@ -6,6 +6,7 @@ in stored options when the installed holidays version changes underneath an
 existing config entry. The calendar must keep serving the remaining schedules.
 """
 
+import re
 from datetime import date, datetime
 
 import pytest
@@ -149,6 +150,44 @@ async def test_renamed_holiday_falls_back_to_contains_lookup(
     assert events[0].summary == "Thanksgiving"
     # Thanksgiving Day 2026 is November 26
     assert events[0].start == date(2026, 11, 26)
+
+
+def test_no_unintended_base_class_overrides() -> None:
+    """Members defined on SchedulerCalendar must not shadow CalendarEntity.
+
+    HA 2026.6 added CalendarEntity._async_update_listener, which the calendar
+    dashboard's event subscription invokes. Our options-update listener used
+    to share that name with an incompatible signature, so every dashboard
+    subscription raised TypeError and the dashboard showed no events. Guard
+    against any future accidental shadowing of base-class members.
+    """
+    from homeassistant.components.calendar import CalendarEntity
+
+    from custom_components.ha_scheduler.calendar import SchedulerCalendar
+
+    intentional_overrides = {
+        "_attr_has_entity_name",
+        "async_added_to_hass",
+        "async_will_remove_from_hass",
+        "extra_state_attributes",
+        "event",
+        "async_get_events",
+    }
+
+    shadowed = {
+        name
+        for name in SchedulerCalendar.__dict__
+        if not name.startswith("__")
+        and not name.startswith("_abc_")
+        and not re.match(r"_[A-Z]", name)  # name-mangled (_ClassName__attr)
+        and hasattr(CalendarEntity, name)
+        and name not in intentional_overrides
+    }
+
+    assert not shadowed, (
+        f"SchedulerCalendar unintentionally overrides CalendarEntity members: "
+        f"{sorted(shadowed)}"
+    )
 
 
 async def test_legacy_options_layout_still_lists_events(


### PR DESCRIPTION
## Problem

Even after #51, the production HA 2026.6 instance showed no events in the Calendar dashboard. The log pinpoints it:

```
TypeError: SchedulerCalendar._async_update_listener() takes 3 positional arguments but 4 were given
  File ".../homeassistant/components/calendar/__init__.py", line 722, in async_update_single_event_listener
    self._async_update_listener(start_date, end_date, listener)
```

HA 2026.6 added `CalendarEntity._async_update_listener(start_date, end_date, listener)`, which the calendar dashboard's websocket event subscription invokes. `SchedulerCalendar`'s config-entry **options** listener shared that name with an incompatible signature, so every dashboard subscription raised `TypeError` and the dashboard rendered zero events — while the entity itself and `async_get_events` were perfectly healthy. HA 2026.2 (the dev/test environment) doesn't have the base method yet, so the local suite couldn't catch it.

## Changes

- Rename the options-update listener to `_async_options_updated`, with a comment explaining why the old name is forbidden.
- Add a regression test that fails if any member defined on `SchedulerCalendar` unintentionally shadows a `CalendarEntity` member (catches this class of bug on whichever HA version CI runs).
- Fix the HA blocking-call warnings also present in the log: resolving a week schedule's first weekday during the entity's first state write loaded Babel locale data files inside the event loop (1.3 s state write). Locale data is now primed in the executor at setup and on options updates, mirroring the holiday-cache priming.

## Testing

- 266 tests pass; ruff and pre-commit clean.
- The shadow-guard test is version-sensitive by design: on HA ≥ 2026.6 it fails with the old method name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)