### PR TITLE
Enforce strict typing (quality-scale strict-typing, Platinum)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run ruff format check
         run: ruff format --check custom_components/ tests/
+
+      - name: Run mypy (strict typing)
+        run: mypy custom_components/ha_scheduler/

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+.mypy_cache/
 
 # Virtual environments
 .venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,16 @@ repos:
 
   - repo: local
     hooks:
+      # Enforce strict typing (quality-scale strict-typing rule). Uses a local
+      # system hook so mypy resolves against the installed Home Assistant deps
+      # rather than an isolated mirrors-mypy env; config lives in mypy.ini.
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
       # Run pytest on all tests
       - id: pytest-check
         name: pytest-check

--- a/custom_components/ha_scheduler/calendar.py
+++ b/custom_components/ha_scheduler/calendar.py
@@ -192,7 +192,8 @@ class SchedulerCalendar(CalendarEntity):
         """Return live service data, handling both new and legacy layouts."""
         services = self._entry.options.get("services", {})
         if services:
-            return services.get(self._service_id, {})
+            service: dict[str, Any] = services.get(self._service_id, {})
+            return service
 
         # Legacy (pre-services) entries store schedules at the options root.
         return {

--- a/custom_components/ha_scheduler/config_flow.py
+++ b/custom_components/ha_scheduler/config_flow.py
@@ -84,7 +84,7 @@ def _get_schedule_type_display(schedule_type: str) -> str:
     return display_names.get(schedule_type, schedule_type)
 
 
-def _validate_yaml_config(yaml_str: str) -> dict | list | None:
+def _validate_yaml_config(yaml_str: str) -> dict[str, Any] | list[Any] | None:
     """Validate YAML configuration string.
 
     Returns the parsed structure (dict or list) if valid, ``None`` for an
@@ -485,7 +485,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 errors.update(await self._validate_schedule_conflicts(data, schedules))
 
                 if not errors:
-                    updated_options = self._save_schedule(self._schedule_id, data)
+                    schedule_id = self._schedule_id
+                    if schedule_id is None:
+                        return self.async_abort(reason="unknown")
+                    updated_options = self._save_schedule(schedule_id, data)
 
                     return self.async_create_entry(title="", data=updated_options)
 
@@ -510,7 +513,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             ).strip()
 
         # Only use config_value as placeholder, not as default (to allow clearing)
-        schema_dict = {
+        schema_dict: dict[vol.Marker, Any] = {
             vol.Required("name", default=defaults.get("name", "My Schedule")): str,
             vol.Required(
                 "start_month", default=str(defaults.get("start_month", 1))
@@ -643,7 +646,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     )
 
                 if not errors:
-                    updated_options = self._save_schedule(self._schedule_id, data)
+                    schedule_id = self._schedule_id
+                    if schedule_id is None:
+                        return self.async_abort(reason="unknown")
+                    updated_options = self._save_schedule(schedule_id, data)
 
                     return self.async_create_entry(title="", data=updated_options)
 
@@ -682,7 +688,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         else:
             end_week_display = str(end_week_default)
 
-        schema_dict = {
+        schema_dict: dict[vol.Marker, Any] = {
             vol.Required("name", default=defaults.get("name", "My Schedule")): str,
             vol.Required(
                 "start_month", default=str(defaults.get("start_month", 1))
@@ -785,7 +791,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 errors.update(await self._validate_schedule_conflicts(data, schedules))
 
                 if not errors:
-                    updated_options = self._save_schedule(self._schedule_id, data)
+                    schedule_id = self._schedule_id
+                    if schedule_id is None:
+                        return self.async_abort(reason="unknown")
+                    updated_options = self._save_schedule(schedule_id, data)
 
                     return self.async_create_entry(title="", data=updated_options)
 
@@ -809,7 +818,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 config_value, default_flow_style=False, sort_keys=False
             ).strip()
 
-        schema_dict = {
+        schema_dict: dict[vol.Marker, Any] = {
             vol.Required("name", default=defaults.get("name", "My Schedule")): str,
             vol.Required(
                 "month", default=str(defaults.get("month", 1))
@@ -1023,7 +1032,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     )
 
                 if not errors:
-                    updated_options = self._save_schedule(self._schedule_id, data)
+                    schedule_id = self._schedule_id
+                    if schedule_id is None:
+                        return self.async_abort(reason="unknown")
+                    updated_options = self._save_schedule(schedule_id, data)
 
                     return self.async_create_entry(title="", data=updated_options)
 
@@ -1060,7 +1072,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 holiday_options[0]["value"] if holiday_options else ""
             )
 
-        schema_dict = {
+        schema_dict: dict[vol.Marker, Any] = {
             vol.Required(
                 "name", default=defaults.get("name", "My Holiday Schedule")
             ): str,
@@ -1199,7 +1211,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """Confirm schedule removal."""
         if user_input is not None:
             if user_input.get("confirm"):
-                updated_options = self._remove_schedule(self._schedule_id)
+                schedule_id = self._schedule_id
+                if schedule_id is None:
+                    return self.async_abort(reason="unknown")
+                updated_options = self._remove_schedule(schedule_id)
 
                 return self.async_create_entry(title="", data=updated_options)
 

--- a/custom_components/ha_scheduler/holiday_importer.py
+++ b/custom_components/ha_scheduler/holiday_importer.py
@@ -96,7 +96,7 @@ def get_localized_country_name(
 
         en_locale = Locale("en")
         if country_code.upper() in en_locale.territories:
-            return en_locale.territories[country_code.upper()]
+            return str(en_locale.territories[country_code.upper()])
     except Exception as e:  # noqa: BLE001 - graceful fallback around third-party library quirks
         # Any error including ImportError
         _LOGGER.debug("Could not look up territory name: %s", e)
@@ -303,6 +303,11 @@ def _get_named_holiday_dates_sync(
             languages_to_try.insert(0, default_language)
 
         for lang in languages_to_try:
+            # holidays_module cannot be None here (a provider object exists),
+            # but narrow explicitly to satisfy the type checker and mirror the
+            # defensive checks elsewhere in this file.
+            if holidays_module is None:
+                break
             try:
                 kwargs: dict[str, Any] = {"years": year, "language": lang}
                 if category and category != "public":

--- a/custom_components/ha_scheduler/quality_scale.yaml
+++ b/custom_components/ha_scheduler/quality_scale.yaml
@@ -126,4 +126,7 @@ rules:
   inject-websession:
     status: exempt
     comment: No HTTP communication.
-  strict-typing: todo
+  strict-typing:
+    status: done
+    comment: mypy --strict passes over the integration (config in mypy.ini)
+      and is enforced by the mypy step in the Lint CI workflow.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+# Enforces the Home Assistant quality-scale `strict-typing` rule.
+# Run bare `mypy` to check the integration; CI runs the same via lint.yml.
+strict = true
+files = custom_components/ha_scheduler

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,6 +2,8 @@ pytest>=9.0.0
 pytest-homeassistant-custom-component>=0.13.339
 pytest-cov>=7.1.0
 ruff>=0.15.20
+mypy>=2.1.0
+types-PyYAML
 pre-commit>=4.6.0
 babel>=2.18.0
 holidays>=0.99


### PR DESCRIPTION
## Summary

Makes `mypy --strict` pass over the integration and enforces it in CI, completing the Platinum **`strict-typing`** quality-scale rule (`todo` → `done`). For a custom integration this rule means "keep mypy strict green in CI" — there is no core `.strict-typing` registration involved.

Fixes the 13 baseline `mypy --strict` errors across `config_flow.py`, `holiday_importer.py`, and `calendar.py`. All changes are pure annotations/narrowing with **no behavior change** — the full 280-test suite stays green.

## Type fixes
- **`config_flow.py`**
  - Annotate `_validate_yaml_config` return with generic args (`dict[str, Any] | list[Any] | None`).
  - Annotate the four configure-step `schema_dict` literals as `dict[vol.Marker, Any]` so the later `vol.Optional(...)` insert type-checks. (One of the four previously type-checked only by accident because its literal happened to contain an `Optional` key.)
  - Narrow `self._schedule_id` (`str | None`) at the five `_save_schedule`/`_remove_schedule` call sites via a defensive `async_abort` guard. *(The plan's preferred `assert` would trip ruff's bandit `S101`, which is enabled for source and only ignored in `tests/`; `async_abort` is also the codebase's established idiom.)*
- **`holiday_importer.py`** — wrap the Babel territory lookup in `str(...)`; add an explicit `holidays_module is None` guard as the first statement of the language-retry loop.
- **`calendar.py`** — annotate the intermediate service dict to avoid an `Any` return.

## CI + config wiring
- Add `mypy.ini` (`strict = true`, `files = custom_components/ha_scheduler`) so contributors can run bare `mypy`.
- Add `mypy>=2.1.0` and `types-PyYAML` to `requirements_test.txt`.
- Add a `mypy` step to the Lint workflow and a local `mypy` pre-commit hook (system hook, so it resolves against installed HA deps rather than an isolated env).
- Ignore `.mypy_cache/` in `.gitignore`.
- `quality_scale.yaml`: `strict-typing` `todo` → `done`.

## Verification
- `mypy --strict custom_components/ha_scheduler/` → **Success: no issues found in 8 source files**
- `ruff check` / `ruff format --check` → clean
- `pytest tests/` → **280 passed**

## Notes
- Strict mode is rechecked against whatever HA version installs at CI time (floors are unpinned); new HA releases occasionally tighten annotations and can surface new errors. The weekly scheduled test run will flag such drift as normal maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)