### PR TITLE
fix(lint): drop stale BLE001 noqa and bound lint tooling to a minor series

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,8 +46,10 @@ ruff check custom_components/ tests/ && ruff format --check custom_components/ t
 
 CI runs tests on Python 3.14 with a 95% coverage gate, ruff over
 `custom_components/` and `tests/`, hassfest + HACS validation, and CodeQL.
-Dependencies are unpinned floors; a weekly scheduled test run catches
-upstream `holidays`/`babel`/`homeassistant` changes.
+Runtime dependencies are unpinned floors; a weekly scheduled test run catches
+upstream `holidays`/`babel`/`homeassistant` changes. Lint tooling (`ruff`,
+`mypy`) is bounded to a minor series instead, so a new rule cannot turn CI red
+without a commit; pre-commit runs ruff from that same install.
 
 ## Conventions and gotchas
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,11 +19,24 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    # Group all patch and minor updates together
+    # Group all patch and minor updates together, except the lint tooling.
+    # ruff/mypy bumps can turn CI red on their own (new or changed rules), so
+    # they get their own group: a lint break then fails an isolated PR instead
+    # of blocking every other dependency update bundled alongside it.
     groups:
+      lint-tooling:
+        patterns:
+          - "ruff"
+          - "mypy"
+        update-types:
+          - "minor"
+          - "patch"
       python-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "ruff"
+          - "mypy"
         update-types:
           - "minor"
           - "patch"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,20 +3,24 @@
 # Run manually: pre-commit run --all-files
 
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+  - repo: local
     hooks:
-      # Run the linter
-      - id: ruff
-        args: [--fix]
+      # Ruff runs as a local system hook (like mypy and pytest below) so its
+      # version comes from requirements_test.txt alone. A pinned `rev:` here
+      # would be a second, independently drifting source of the ruff version,
+      # and dependabot does not watch the pre-commit ecosystem.
+      - id: ruff-check
+        name: ruff check
+        entry: python -m ruff check --fix custom_components/ tests/
+        language: system
         pass_filenames: false
         always_run: true
-        exclude: '.*\.md$'
-      # Run the formatter
       - id: ruff-format
+        name: ruff format
+        entry: python -m ruff format custom_components/ tests/
+        language: system
         pass_filenames: false
         always_run: true
-        exclude: '.*\.md$'
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,10 @@ ruff check custom_components/ tests/ && ruff format --check custom_components/ t
 
 CI runs tests on Python 3.14 with a 95% coverage gate, ruff over
 `custom_components/` and `tests/`, hassfest + HACS validation, and CodeQL.
-Dependencies are unpinned floors; a weekly scheduled test run catches
-upstream `holidays`/`babel`/`homeassistant` changes.
+Runtime dependencies are unpinned floors; a weekly scheduled test run catches
+upstream `holidays`/`babel`/`homeassistant` changes. Lint tooling (`ruff`,
+`mypy`) is bounded to a minor series instead, so a new rule cannot turn CI red
+without a commit; pre-commit runs ruff from that same install.
 
 ## Conventions and gotchas
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -106,7 +106,7 @@ Now every commit will automatically:
 - Format code with Ruff
 - Remove trailing whitespace
 - Validate YAML files
-- Run tests on changed files
+- Run the full test suite
 
 **Important**: Pre-commit uses the Python environment where it was installed. Always activate your virtual environment before committing:
 ```bash
@@ -196,6 +196,11 @@ pre-commit run --all-files
 # Update pre-commit hooks
 pre-commit autoupdate
 ```
+
+`autoupdate` does not manage ruff, mypy, or pytest: those run as local
+`system` hooks against the versions installed from `requirements_test.txt`,
+so bump them there (dependabot opens those PRs) and re-run `pip install -r
+requirements_test.txt`.
 
 ## Running Home Assistant Locally
 
@@ -378,7 +383,7 @@ This project follows Home Assistant's coding standards:
 - Ruff for linting and formatting
 - Pytest for testing
 - American English for all text
-- Test coverage at or above the 80% CI gate
+- Test coverage at or above the 95% CI gate
 
 ## Troubleshooting
 

--- a/custom_components/ha_scheduler/calendar.py
+++ b/custom_components/ha_scheduler/calendar.py
@@ -260,7 +260,7 @@ class SchedulerCalendar(CalendarEntity):
                             active_events.append((event.start, event, schedule))
                         elif schedule_start > today:
                             future_events.append((event.start, event, schedule))
-            except Exception:  # noqa: BLE001 - one bad schedule must not hide the others
+            except Exception:  # one bad schedule must not hide the others
                 _LOGGER.warning(
                     "Skipping schedule %r while determining the current event",
                     schedule.get("name", schedule.get("uid")),
@@ -355,7 +355,7 @@ class SchedulerCalendar(CalendarEntity):
                                     description="",
                                 )
                             )
-            except Exception:  # noqa: BLE001 - one bad schedule must not hide the others
+            except Exception:  # one bad schedule must not hide the others
                 _LOGGER.warning(
                     "Skipping schedule %r while listing calendar events",
                     schedule.get("name", schedule.get("uid")),

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,8 +1,13 @@
 pytest>=9.0.0
 pytest-homeassistant-custom-component>=0.13.346
 pytest-cov>=7.1.0
-ruff>=0.15.21
-mypy>=2.3.0
+# Lint tooling is bounded to a minor series: ruff 0.x minors add and change
+# rules, so an open-ended floor lets a new release turn CI red with no commit.
+# 0.16 is the series that treats `logging.<level>(..., exc_info=True)` as a
+# handled blind except (see the broad catches in calendar.py), and is the
+# series Home Assistant core itself pins to.
+ruff>=0.16,<0.17
+mypy>=2.3,<3
 types-PyYAML
 pre-commit>=4.6.0
 babel>=2.18.0

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -26,8 +26,8 @@ if [ "$PY_MINOR" -lt 14 ]; then
 fi
 
 # Install development dependencies (includes pre-commit).
-# --upgrade matters: requirements are unpinned floors, and a stale venv can
-# mask bugs that only occur with the holidays/homeassistant versions users
+# --upgrade matters: runtime requirements are unpinned floors, and a stale venv
+# can mask bugs that only occur with the holidays/homeassistant versions users
 # actually run.
 echo "📚 Installing development dependencies (latest versions)..."
 pip install --upgrade -r requirements_test.txt


### PR DESCRIPTION
## Why

Lint went red on `main` with no commit behind it.

Ruff 0.16.0 widened the `BLE001` carve-out for properly-logged blind excepts: it previously recognised only `logging.exception()`, and now also accepts `logging.<level>(..., exc_info=True)`. The two broad catches in `calendar.py` are the only ones in the repo that pass `exc_info=True` (of 19 `# noqa: BLE001` sites), so `BLE001` went quiet there and `RUF100` began flagging the now-redundant directives.

Nothing in the repo changed. `ruff` was an open-ended floor (`>=0.15.21`), so CI installed whatever was newest at run time. Lint had not actually run on `main` since 2026-07-09, before 0.16.0 shipped.

Worth noting: floor bumps on a linter never test the version CI installs. #70 bumped `>=0.15.20` → `>=0.15.21` and passed while CI was already running 0.16.x.

## What changed

- **`calendar.py`** — removed the two dead `# noqa: BLE001` directives, keeping the rationale as prose. The handlers still log at **WARNING with a traceback**; behaviour is unchanged and no test assertions move. A skipped schedule is recovered (the other schedules still render), so it is degraded rather than broken, and WARNING remains the right severity.
- **`requirements_test.txt`** — `ruff>=0.16,<0.17`, `mypy>=2.3,<3`. Bounding to a minor series stops a new release changing CI results with no commit. 0.16.x is also the series Home Assistant core pins to (core `dev` pins `ruff==0.16.1`).
- **`.pre-commit-config.yaml`** — ruff now runs as a local `system` hook off `requirements_test.txt`, matching the existing mypy/pytest hooks. The pinned `rev: v0.15.12` was a second, independently drifting source of the ruff version, and dependabot does not watch the pre-commit ecosystem. Paths are explicit because ruff 0.16 formats Python blocks in Markdown by default. Also drops `exclude` config that could never match, since these hooks pass no filenames.
- **`.github/dependabot.yml`** — ruff/mypy get their own group, so a lint break fails an isolated PR instead of blocking every other dependency bundled into the grouped update.
- **Docs** — corrected what this change made stale, plus two pre-existing errors: the coverage gate is 95% not 80%, and the pytest hook runs the full suite rather than changed files. `copilot-instructions.md` mirrors `AGENTS.md` verbatim and was resynced.

## On the trade-off

Keeping the directives as `# noqa: BLE001, RUF100` also lints clean on both 0.15.x and 0.16.x — `RUF100` self-suppresses — so the version bound is a reproducibility choice, not a logical necessity. It was rejected because it buys cross-version tolerance by permanently disabling stale-suppression detection at exactly the two lines that just went stale, which is the check that caught this. Bounding the tool keeps `RUF100` working everywhere.

Switching to `_LOGGER.exception()` would also be version-agnostic, but changes the log severity to ERROR as a side effect of a lint fix.

## Verification

- `ruff check` and `ruff format --check` clean on **0.16.0, 0.16.1 and 0.16.3**; 0.15.21 (excluded by the bound) is the version that fails, so the bound does real work.
- 403 tests pass, 99.88% coverage, mypy strict clean.
- Full `pre-commit run` passes with the new local hooks.

## Known follow-up, not fixed here

`trailing-whitespace` and `end-of-file-fixer` are configured with `pass_filenames: false`, so they receive zero filenames and silently do nothing. Verified: a file with trailing whitespace passes the hook untouched. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
