### PR TITLE
ci: enforce the repo hygiene hooks, and default hooks to the commit stage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,19 @@ jobs:
 
       - name: Run mypy (strict typing)
         run: mypy custom_components/ha_scheduler/
+
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-py3.14-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      # ruff, mypy and pytest already run as their own steps here and in the
+      # Test workflow, so they are skipped rather than run twice. What is left
+      # is the whitespace/YAML/large-file/merge-marker hooks, which nothing
+      # else enforces: they otherwise bind only developers who ran
+      # `pre-commit install`, not web edits or a fresh clone.
+      - name: Run repo hygiene hooks
+        env:
+          SKIP: ruff-check,ruff-format,mypy,pytest-check
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,11 @@
 # Install: pre-commit install
 # Run manually: pre-commit run --all-files
 
+# Every hook here is a commit-time check. Setting this once keeps the ruff,
+# mypy and pytest hooks consistent: without it they default to running at
+# every stage, so installing a pre-push hook would fire them there too.
+default_stages: [pre-commit]
+
 repos:
   - repo: local
     hooks:
@@ -52,7 +57,6 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-        stages: [pre-commit]
       # Run pytest on all tests
       - id: pytest-check
         name: pytest-check
@@ -60,4 +64,3 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-        stages: [pre-commit]


### PR DESCRIPTION
Follow-up to #79, closing the gap that let its bug go unnoticed for months.

## The gap

CI runs ruff, mypy and pytest as direct steps and never invokes pre-commit. So five hooks were enforced **nowhere**:

- `trailing-whitespace`
- `end-of-file-fixer`
- `check-yaml`
- `check-added-large-files`
- `check-merge-conflict`

They bound only developers who had run `pre-commit install` — not GitHub web edits, not a fresh clone, not a contributor who skipped setup.

This is not hypothetical. It is exactly how `SPEC.md` accumulated 18 lines of trailing whitespace (fixed in #79): the hooks were no-ops locally *and* absent from CI, so nothing gated them.

## The change

A lint step that runs pre-commit with the already-covered hooks skipped, so pytest does not run twice:

```yaml
      - name: Run repo hygiene hooks
        env:
          SKIP: ruff-check,ruff-format,mypy,pytest-check
        run: pre-commit run --all-files --show-diff-on-failure
```

- **Cheap.** The five remaining hooks run in well under a second.
- **Cached.** `actions/cache@v6` keys hook environments on the `.pre-commit-config.yaml` hash, so the ~20s clone-and-build cost is not paid on every push.
- **Actionable.** `--show-diff-on-failure` prints exactly what the fixers would rewrite, so a contributor does not have to reproduce it locally to understand the failure.

## Proof the gate can actually fail

A gate that cannot fail is precisely the bug #79 just fixed, so this was verified rather than assumed. Staging a YAML file with trailing whitespace and no final newline, then running the exact CI command:

```
trim trailing whitespace.......Failed
- hook id: trailing-whitespace
- exit code: 1
- files were modified by this hook
fix end of files...............Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook
```

Both fixers fail and the diff is printed. On the clean tree, all five pass.

## Also: `default_stages`

Every hook in this config is a commit-time check, but only `mypy` and `pytest-check` said so. The rest defaulted to running at *every* stage, so installing a pre-push hook would have fired `ruff-check`/`ruff-format` there while mypy and pytest stayed behind.

Setting `default_stages: [pre-commit]` once and dropping the two now-redundant per-hook `stages:` entries makes it uniform, and is one line shorter.

**No behavior change today** — only the `pre-commit` git hook type is installed, so nothing currently runs at another stage. This makes the config correct if that ever changes.

## Verification

- `pre-commit validate-config` passes; `lint.yml` parses.
- Full `pre-commit run --all-files` passes on the clean tree (all nine hooks).
- The gate fails on a real violation, as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
